### PR TITLE
mod - using slotInEpoch from db for block slotNo in bestBlock and txH…

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -10,7 +10,7 @@ import { Pool } from "pg";
 const semverCompare = require("semver-compare");
 
 import { connectionHandler} from "./ws-server"; 
-import { applyMiddleware, applyRoutes, BLOCK_SIZE, contentTypeHeaders, graphqlEndpoint, Route } from "./utils";
+import { applyMiddleware, applyRoutes, contentTypeHeaders, graphqlEndpoint, Route } from "./utils";
 import * as utils from "./utils";
 import * as middleware from "./middleware";
 
@@ -54,7 +54,7 @@ const bestBlock = async (req: Request, res: Response) => {
     const cardano = result.value;
     res.send({
       epoch: cardano.currentEpoch.number,
-      slot: cardano.currentEpoch.blocks[0].slotNo % BLOCK_SIZE ,
+      slot: cardano.currentEpoch.blocks[0].slotInEpoch,
       hash: cardano.currentEpoch.blocks[0].hash,
       height: cardano.currentEpoch.blocks[0].number,
     });

--- a/src/services/bestblock.ts
+++ b/src/services/bestblock.ts
@@ -15,6 +15,7 @@ export interface BlockFrag {
     hash: string;
     number: number;
     slotNo: number;
+    slotInEpoch: number;
 }
 
 export const askBestBlock = async () : Promise<UtilEither<CardanoFrag>> => {
@@ -27,6 +28,7 @@ export const askBestBlock = async () : Promise<UtilEither<CardanoFrag>> => {
                         hash
                         number
                         slotNo
+                        slotInEpoch
                       }
                     }
                   },

--- a/src/services/transactionHistory.ts
+++ b/src/services/transactionHistory.ts
@@ -1,6 +1,6 @@
 import axios from "axios";
 
-import {  BLOCK_SIZE, contentTypeHeaders, errMsgs, graphqlEndpoint, UtilEither} from "../utils";
+import {  contentTypeHeaders, errMsgs, graphqlEndpoint, UtilEither} from "../utils";
 
 import { Pool } from "pg";
 
@@ -39,6 +39,7 @@ const askTransactionSqlQuery = `
        , block.hash as "blockHash"
        , block.epoch_no as "blockEpochNo"
        , block.slot_no as "blockSlotNo"
+       , block.epoch_slot_no as "blockSlotInEpoch"
        , case when vrf_key is null then 'byron' 
               else 'shelley' end 
          as blockEra
@@ -175,7 +176,7 @@ export const askTransactionHistory = async (
     const blockFrag : BlockFrag = { number: row.blockNumber
       , hash: row.blockHash.toString("hex")
       , epochNo: row.blockEpochNo
-      , slotNo: row.blockSlotNo % BLOCK_SIZE };
+      , slotNo: row.blockSlotInEpoch };
     return { hash: row.hash.toString("hex")
       , block: blockFrag
       , fee: row.fee.toString()

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -6,8 +6,6 @@ export const graphqlEndpoint:string = config.get("server.graphqlEndpoint");
 
 export const errMsgs = { noValue: "no value" };
 
-export const BLOCK_SIZE = 21600;
-
 type Wrapper = ((router: Router) => void);
 
 export const applyMiddleware = (


### PR DESCRIPTION
…istory.

This fixes a bug wherein the wrong block slot number was computed.
In byron we computed this by taking the absoluate slot number and computing
the mod.

Slot no are more complicated now, though, luckily, db-sync-3.1.0 introduced
SlotInEpoch to make it easy to get it.