### PR TITLE
Feature/certs

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,29 +200,29 @@ Array<{
     address: string,
     amount: string,
   }>,
-  withdrawals: Array<{| address: string,
+  withdrawals: Array<{| address: string, // hex
     amount: string
   |}>,
   certificates: Array<{|
     kind: 'StakeRegistration',
-    stakeCredential: string,
+    stakeCredential: string, //hex
   |} | {|
     kind: 'StakeDeregistration',
-    stakeCredential: string,
+    stakeCredential: string, // hex
   |} | {|
     kind: 'StakeDelegation',
-    stakeCredential: string,
-    poolKeyHash: string,
+    stakeCredential: string, // hex
+    poolKeyHash: string, // hex
   |} | {|
     kind: 'PoolRegistration',
     poolParams: {|
-      operator: string,
-      vrfKeyHash: string,
-      pledge: string,
+      operator: string, // hex
+      vrfKeyHash: string, // hex
+      pledge: number, 
       cost: string,
       margin: number,
-      rewardAccount: string,
-      poolOwners: Array<string>,
+      rewardAccount: string, // hex
+      poolOwners: Array<string>,  // hex
       relays: Array<{| ipv4: string, 
         ipv6: string, 
         dnsName: string, 
@@ -230,16 +230,16 @@ Array<{
         port: string |}>,
       poolMetadata: null | {|
         url: string,
-        metadataHash: string,
+        metadataHash: string, //hex
       |},
     |},
   |} | {|
     type: 'PoolRetirement',
-    poolKeyHash: string,
+    poolKeyHash: string, // hex
     epoch: number,
   |} {|
     type: 'MoveInstantaneousRewardsCert',
-    rewards: Array<string>,
+    rewards: Array<string>, // hex of stake addresses
     pot: 'Reserve' | 'Treasury'
   |}>
 }>;

--- a/src/Transactions/certificates.ts
+++ b/src/Transactions/certificates.ts
@@ -1,0 +1,208 @@
+import { Pool } from "pg";
+
+export const createViewSql = `
+drop view if exists combined_certificates;
+create view combined_certificates as
+select 'StakeRegistration' as "jsType"
+     , 'CertRegKey' as "formalType"
+     , reg.tx_id as "txId"
+     , reg.cert_index as "certIndex"
+     , encode(addr.hash,'hex') as "stakeCred"
+     , null::text as "poolHashKey"
+     , null::text as "poolParamsOperator"
+     , null::text as "poolParamsVrfKeyHash"
+     , null::numeric as "poolParamsPledge"
+     , null::bigint as "poolParamsCost"
+     , null::double precision as "poolParamsMargin"
+     , null::text as "poolParamsRewardAccount"
+     , null::json as "poolParamsOwners"
+     , null::json as "poolParamsRelays"
+     , null as "poolParamsMetaDataUrl"
+     , null::text as "poolParamsMetaDataHash"
+     , null::integer as "epoch"
+     , null as "mirPot"
+     , null::json as "rewards"
+from stake_registration as reg
+join stake_address as addr 
+  on reg.addr_id = addr.id
+
+UNION ALL
+  
+select 'StakeDeregistration' as "jsType"
+     , 'CertDeregKey' as "formalType"
+     , dereg.tx_id as "txId"
+     , dereg.cert_index as "certIndex"
+     , encode(addr.hash,'hex') as "stakeCred"
+     , null::text as "poolHashKey"
+     , null::text as "poolParamsOperator"
+     , null::text as "poolParamsVrfKeyHash"
+     , null::numeric as "poolParamsPledge"
+     , null::bigint as "poolParamsCost"
+     , null::double precision as "poolParamsMargin"
+     , null::text as "poolParamsRewardAccount"
+     , null::json as "poolParamsOwners"
+     , null::json as "poolParamsRelays"
+     , null as "poolParamsMetaDataUrl"
+     , null::text as "poolParamsMetaDataHash"
+     , null::integer as "epoch"
+     , null as "mirPot"
+     , null::json as "rewards"
+from stake_deregistration as dereg
+join stake_address as addr
+  on dereg.addr_id = addr.id
+
+UNION ALL
+  
+select 'StakeDelegation' as "jsType"
+     , 'CertDelegate' as "formalType"
+     , del.tx_id as "txId"
+     , del.cert_index as "certIndex"
+     , encode(addr.hash,'hex') as "stakeCred"
+     , encode(pool_hash.hash, 'hex') as "poolHashKey"
+     , null::text as "poolParamsOperator"
+     , null::text as "poolParamsVrfKeyHash"
+     , null::numeric as "poolParamsPledge"
+     , null::bigint as "poolParamsCost"
+     , null::double precision as "poolParamsMargin"
+     , null::text as "poolParamsRewardAccount"
+     , null::json as "poolParamsOwners"
+     , null::json as "poolParamsRelays"
+     , null as "poolParamsMetaDataUrl"
+     , null::text as "poolParamsMetaDataHash"
+     , null::integer as "epoch"
+     , null as "mirPot"
+     , null::json as "rewards"
+from delegation as del
+join stake_address as addr
+  on del.addr_id = addr.id
+join pool_update 
+  on del.update_id = pool_update.id
+join pool_hash
+  on pool_update.hash_id = pool_hash.id
+
+UNION ALL
+  
+select 'PoolRegistration' as "jsType"
+     , 'CertRegPool' as "formalType"
+     , pool.registered_tx_id as "txId" 
+     , pool.cert_index as "certIndex"
+     , null as "stakeCred"
+     , null::text as "poolHashKey"
+     , encode(pool_hash.hash,'hex') as "poolParamsOperator" 
+           -- this is weird.  a hash of pool operator (see pg 30 of A Formal 
+           -- Spec of the Cardano Ledger) can be acquired by the cwitness 
+           -- accessor.  it also says (pg 37) that the stake pool is identified
+           -- with the hashkey of the pool operator. looking through Insert.hs,
+           -- it is clear that there is a hash that's identified with the stake
+           -- pool.  it is this one!
+     , encode(pool.vrf_key,'hex') as "poolParamsVrfKeyHash"
+     , pool.pledge as "poolParamsPledge"
+     , pool.fixed_cost as "poolParamsCost"
+     , pool.margin as "poolParamsMargin"
+     , encode(addr.hash,'hex') as "poolParamsRewardAccount"
+     , ( select json_agg(encode(hash,'hex'))
+         from pool_owner
+         where pool_owner.pool_id = pool_hash.id) as "poolParamsOwners" 
+     , ( select json_agg(json_build_object( 'ipv4',       ipv4
+     					  , 'ipv6',       ipv6
+     					  , 'dnsName',    dns_name
+     					  , 'dnsSrvName', dns_srv_name
+     					  , 'port',       port)) 
+         from pool_relay
+         where pool_relay.update_id = pool.id) as "poolParamsRelays"
+     , pool_meta.url as "poolParamsMetaDataUrl"
+     , encode(pool_meta.hash,'hex') as "poolParamsMetaDataHash"
+     , null::integer as "epoch"
+     , null as "mirPot"
+     , null::json as "rewards"
+from pool_update as pool
+join pool_hash
+  on pool.hash_id = pool_hash.id
+join stake_address as addr
+  on addr.id = pool.reward_addr_id
+left join pool_meta_data as pool_meta
+  on pool_meta.id = pool.meta
+
+UNION ALL
+  
+select 'PoolRetirement' as "jsType"
+     , 'CertRetirePool' as "formalType"
+     , pool.announced_tx_id as "txId"
+     , pool.cert_index as "certIndex"
+     , null as "stakeCred"
+     , encode(pool_hash.hash, 'hex') as "poolHashKey"
+     , null::text as "poolParamsOperator"
+     , null::text as "poolParamsVrfKeyHash"
+     , null::numeric as "poolParamsPledge"
+     , null::bigint as "poolParamsCost"
+     , null::double precision as "poolParamsMargin"
+     , null::text as "poolParamsRewardAccount"
+     , null::json as "poolParamsOwners"
+     , null::json as "poolParamsRelays"
+     , null as "poolParamsMetaDataUrl"
+     , null::text as "poolParamsMetaDataHash"
+     , pool.retiring_epoch as "epoch"
+     , null as "mirPot"
+     , null::json as "rewards"
+from pool_retire as pool
+join pool_update as pu
+  on pu.id = pool.update_id
+join pool_hash 
+  on pool_hash.id = pu.hash_id
+
+UNION ALL
+  
+select 'MoveInstantaneousRewardsCert' as "jsType"
+     , 'CertMir' as "formalType"
+     , reserve.tx_id as "txId"
+     , max(reserve.cert_index) as "certIndex"  
+     , null as "stakeCred"
+     , null::text as "poolHashKey"
+     , null::text as "poolParamsOperator"
+     , null::text as "poolParamsVrfKeyHash"
+     , null::numeric as "poolParamsPledge"
+     , null::bigint as "poolParamsCost"
+     , null::double precision as "poolParamsMargin"
+     , null::text as "poolParamsRewardAccount"
+     , null::json as "poolParamsOwners"
+     , null::json as "poolParamsRelays"
+     , null as "poolParamsMetaDataUrl"
+     , null::text as "poolParamsMetaDataHash"
+     , null::integer as "epoch"
+     , 'Reserve' as "mirPot"
+     , json_agg((encode(addr.hash,'hex'), reserve.amount)) as "rewards"
+from reserve
+join stake_address as addr
+  on addr.id = reserve.addr_id
+group by reserve.tx_id      
+
+UNION ALL
+
+select 'MoveInstantaneous"rewards"Cert' as "jsType"
+     , 'CertMir' as "formalType"
+     , treasury.tx_id as "txId"
+     , max(treasury.cert_index) as "certIndex"  
+     , null as "stakeCred"
+     , null::text as "poolHashKey"
+     , null::text as "poolParamsOperator"
+     , null::text as "poolParamsVrfKeyHash"
+     , null::numeric as "poolParamsPledge"
+     , null::bigint as "poolParamsCost"
+     , null::double precision as "poolParamsMargin"
+     , null::text as "poolParamsRewardAccount"
+     , null::json as "poolParamsOwners"
+     , null::json as "poolParamsRelays"
+     , null as "poolParamsMetaDataUrl"
+     , null::text as "poolParamsMetaDataHash"
+     , null::integer as "epoch"
+     , 'Treasury' as "mirPot"
+     , json_agg((encode(addr.hash,'hex'), treasury.amount)) as "rewards"
+from treasury
+join stake_address as addr
+  on addr.id = treasury.addr_id
+group by treasury.tx_id;
+;`;
+
+export const createCertificatesView = (pool: Pool) => {
+  pool.query(createViewSql);
+};

--- a/src/Transactions/types.ts
+++ b/src/Transactions/types.ts
@@ -38,29 +38,35 @@ export type Certificate = StakeRegistration | StakeDeregistration | StakeDelegat
 
 export interface StakeRegistration {
   kind: "StakeRegistration";
+  certIndex: number;
   stakeCredential: string;
 }
 export interface StakeDeregistration{
   kind: "StakeDeregistration";
+  certIndex: number;
   stakeCredential: string;
 }
 export interface StakeDelegation{
   kind: "StakeDelegation";
+  certIndex: number;
   stakeCredential: string;
   poolKeyHash: string;
 }
 export interface PoolRegistration{
   kind: "PoolRegistration";
+  certIndex: number;
   poolParams: PoolParams;
 }
 export interface PoolRetirement{
   kind: "PoolRetirement";
+  certIndex: number;
   poolKeyHash: string;
   epoch: number;
   
 }
 export interface MoveInstantaneousRewardsCert{
   kind: "MoveInstantaneousRewardsCert";
+  certIndex: number;
   pot: "Reserve" | "Treasury";
   rewards: string[];
 }

--- a/src/Transactions/types.ts
+++ b/src/Transactions/types.ts
@@ -1,0 +1,34 @@
+
+export enum BlockEra { Byron = "byron"
+                     , Shelley = "shelley"}
+
+export interface TransactionFrag {
+    hash: string;
+    fee: string;
+    ttl: string;
+    blockEra: BlockEra;
+    metadata: string;
+    block: BlockFrag;
+    includedAt: Date;
+    inputs: TransInputFrag[];
+    outputs: TransOutputFrag[]; // technically a TransactionOutput fragment
+    txIndex: number;
+    withdrawals: TransOutputFrag[];
+}
+export interface BlockFrag {
+    number: number;
+    hash: string;
+    epochNo: number;
+    slotNo: number;
+}
+export interface TransInputFrag {
+    address: string;
+    amount: string;
+    id: string;
+    index: number;
+    txHash: string;
+}
+export interface TransOutputFrag {
+    address: string;
+    amount: string;
+}

--- a/src/Transactions/types.ts
+++ b/src/Transactions/types.ts
@@ -14,6 +14,7 @@ export interface TransactionFrag {
     outputs: TransOutputFrag[]; // technically a TransactionOutput fragment
     txIndex: number;
     withdrawals: TransOutputFrag[];
+    certificates: Certificate[];
 }
 export interface BlockFrag {
     number: number;
@@ -31,4 +32,60 @@ export interface TransInputFrag {
 export interface TransOutputFrag {
     address: string;
     amount: string;
+}
+
+export type Certificate = StakeRegistration | StakeDeregistration | StakeDelegation | PoolRegistration | PoolRetirement | MoveInstantaneousRewardsCert;
+
+export interface StakeRegistration {
+  kind: "StakeRegistration";
+  stakeCredential: string;
+}
+export interface StakeDeregistration{
+  kind: "StakeDeregistration";
+  stakeCredential: string;
+}
+export interface StakeDelegation{
+  kind: "StakeDelegation";
+  stakeCredential: string;
+  poolKeyHash: string;
+}
+export interface PoolRegistration{
+  kind: "PoolRegistration";
+  poolParams: PoolParams;
+}
+export interface PoolRetirement{
+  kind: "PoolRetirement";
+  poolKeyHash: string;
+  epoch: number;
+  
+}
+export interface MoveInstantaneousRewardsCert{
+  kind: "MoveInstantaneousRewardsCert";
+  pot: "Reserve" | "Treasury";
+  rewards: string[];
+}
+
+export interface PoolParams {
+    operator: string;
+    vrfKeyHash: string
+    pledge: string;
+    cost: string;
+    margin: number;
+    rewardAccount: string;
+    poolOwners: string[];
+    relays: PoolRelay[];
+    poolMetadata: null | PoolMetadata;
+}
+
+export interface PoolMetadata {
+    url: string;
+    metadataHash: string;
+}
+
+export interface PoolRelay {
+    ipv4: string;
+    ipv6: string;
+    dnsName: string;
+    dnsSrvName: string
+    port: string;
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -23,11 +23,15 @@ import { handleSignedTx } from "./services/signedTransaction";
 
 import { HealthChecker } from "./HealthChecker";
 
+import { createCertificatesView } from "./Transactions/certificates";
+
 
 const pool = new Pool({ user: config.get("db.user")
   , host: config.get("db.host")
   , database: config.get("db.database")
   , password: config.get("db.password")});
+createCertificatesView(pool);
+
 
 const healthChecker = new HealthChecker(askBestBlock);
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -215,6 +215,7 @@ const txHistory = async (req: Request, res: Response) => {
         //ttl: tx.ttl,
         type: tx.blockEra,
         withdrawals: tx.withdrawals,
+        certificates: tx.certificates,
         tx_ordinal: tx.txIndex,
         tx_state: "Successful", // graphql doesn't handle pending/failed txs
         last_update: tx.includedAt,

--- a/src/services/transactionHistory.ts
+++ b/src/services/transactionHistory.ts
@@ -145,7 +145,11 @@ export const askTransactionHistory = async (
       , txHash: obj.f3}));
     const outputs = row.outAddrValPairs.map( ( obj:any ): TransOutputFrag => ({ address: obj.f1, amount: obj.f2.toString() }));
     const withdrawals : TransOutputFrag[] = row.withdrawals ? row.withdrawals.map( ( obj:any ): TransOutputFrag => ({ address: obj.f1, amount: obj.f2.toString() })) : [];
-    const certificates = row.certificates ? row.certificates.map(rowToCertificate) : [];
+    const certificates = row.certificates !== null
+                        ? row.certificates
+                             .map(rowToCertificate) 
+                             .filter( (i:Certificate|null) => i !== null)
+                        : [];
     const blockFrag : BlockFrag = { number: row.blockNumber
       , hash: row.blockHash.toString("hex")
       , epochNo: row.blockEpochNo
@@ -175,16 +179,19 @@ export const askTransactionHistory = async (
 
 };
 
-const rowToCertificate = (row:any):Certificate => {
+const rowToCertificate = (row:any):Certificate|null => {
   switch(row.jsType){
   case "StakeRegistration":
     return { kind: row.jsType
+      , certIndex: row.certIndex
       , stakeCredential: row.stakeCred };
   case "StakeDeregistration":
     return { kind: row.jsType
+      , certIndex: row.certIndex
       , stakeCredential: row.stakeCred };
   case "StakeDelegation":
     return { kind: row.jsType
+      , certIndex: row.certIndex
       , poolKeyHash: row.poolHashKey
       , stakeCredential: row.stakeCred };
   case "PoolRegistration": {
@@ -213,20 +220,24 @@ const rowToCertificate = (row:any):Certificate => {
           , metadataHash: row.poolParamsMetaDataHash }
     };
     return { kind: row.jsType
+      , certIndex: row.certIndex
       , poolParams: params};
   }
   case "PoolRetirement":
     return { kind: row.jsType
+      , certIndex: row.certIndex
       , poolKeyHash: row.poolHashKey
       , epoch: row.epoch };
   case "MoveInstantaneousRewardsCert":
     return { kind: row.jsType
+      , certIndex: row.certIndex
       , pot: row.mirPot
       , rewards: row.rewards === null
         ? []
         : row.rewards.map( (o:any)=> o.f1) };
   default:
-    throw Error(`Certificate from DB doesn't match any known type: ${row}`);
+    console.log(`Certificate from DB doesn't match any known type: ${row}`); // the app only logs errors.
+    return null
   }
 };
 


### PR DESCRIPTION
* creates view at startup to provide an easy interface to collect all the different types of certs, see 
e77ea8f .  The commit message may be informative.
* adds these certs to the tx history endpoint.
* adds a daft, but not completely useless test (I know its not useless because it found bugs!) on shelley certs.

because of the json aggregation in the sql queries, we must also do the bytea encoding within sql.  I figured this out through much frustration.

note that some of the certificate types changes from the spec I was given on slack.  The spec I had looked like:
```
{|
  type: 'StakeRegistration',
  stake_credential: string,
|} | {|
  type: 'StakeDeregistration',
  stake_credential: string,
|} | {|
  type: 'StakeDelegation',
  stake_credential: string,
  pool_keyhash: string,
|} | {|
  type: 'PoolRegistration',
  pool_params: {|
    operator: string,
    *vrf_keyhash: string,
    *pledge: string,
    *cost: string,
    *margin: {|
      numerator: string,
      denominator: string
    |},
    *reward_account: string,
    *pool_owners: Array<string>,
    *relays: Array<string>,
    *pool_metadata: void | {|
      url: string,
      metadata_hash: string,
    |},
  |},
|} | {|
  type: 'PoolRetirement',
  pool_keyhash: string,
  epoch: number,
|} {|
  type: 'MoveInstantaneousRewardsCert',
  pot: 0 | 1,
  rewards: {| [stake_credential: string]: string /* coin */ |},
|};
```
But the actual result can be found in https://github.com/Emurgo/yoroi-graphql-migration-backend/commit/92aa631e0459f998d93ae1e713800f5a4a8e1369.  
In particular, not that `pool_params.margin` is a float rather than a fractional object.  This reflects the db-sync implementation.
Also note that the `pot` field on `MoveInstantaneousRewardsCert` certs takes values of `Reverse | Treasury`, which better reflects the names in the formal iohk ledger spec.
Finally, note that I preferred camelCase to under_scores.

Finally, I wish to draw your attention to the `PoolParams.operator` field.  It is not clear what this corresponds to in db-sync, so I took a guess.  The thought that they didn't implement it at all was just too horrible to consider.


