### PR TITLE
Fixes to accountState, poolInfo and certificate history

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
-./node_modules
+node_modules
 *.swp
+dist

--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ type RewardInfo = null | {|
 
 ```js
 {
-  poolMetaDataHashes: Array<string> //hash ids of pool meta data.
+  poolIds: Array<string> // operator key
 };
 ```
 
@@ -122,24 +122,21 @@ type RewardInfo = null | {|
 
 ```js
 {
-  [poolMetaDataHash: string]: {| info: RemotePoolInfo,
-                                 history: Array<{|
-                                     epoch: number,
-                                     slot: number,
-                                     tx_ordinal: number
-                                     cert_ordinal: number
-                                     payload: Certificate // see `/api/v2/txs/history`
-                                     |}> 
-                              |}
-                                    
-  
-  type RemotePoolInfo = {
-      pledge_address: string|null, //null if the address is valid but doesn't exist.
+  [poolId: string]: null | {|
+    info: {
       name?: string,
       description?: string,
       ticker?: string,
       ... // other stuff from SMASH.
-  }      
+    },
+    history: Array<{|
+      epoch: number,
+      slot: number,
+      tx_ordinal: number
+      cert_ordinal: number
+      payload: Certificate // see `/api/v2/txs/history`
+    |}>
+  |}
 };
 ```
 
@@ -261,15 +258,15 @@ Array<{
     poolParams: {|
       operator: string, // hex
       vrfKeyHash: string, // hex
-      pledge: string, 
+      pledge: string,
       cost: string,
       margin: number,
       rewardAccount: string, // hex
       poolOwners: Array<string>,  // hex
-      relays: Array<{| ipv4: string|null, 
-        ipv6: string|null, 
-        dnsName: string|null, 
-        dnsSrvName: string|null, 
+      relays: Array<{| ipv4: string|null,
+        ipv6: string|null,
+        dnsName: string|null,
+        dnsSrvName: string|null,
         port: string|null |}>,
       poolMetadata: null | {|
         url: string,
@@ -282,7 +279,7 @@ Array<{
     epoch: number,
   |} {|
     type: 'MoveInstantaneousRewardsCert',
-    rewards: null|{ [addresses: string]: string } // dictionary of stake addresses to their reward amounts in lovelace
+    rewards: { [addresses: string]: string } // dictionary of stake addresses to their reward amounts in lovelace
     pot: 0 | 1 // 0 = Reserves, 1 = Treasury
   |}>
 }>;

--- a/src/Transactions/types.ts
+++ b/src/Transactions/types.ts
@@ -166,7 +166,7 @@ export const rowToCertificate = (row:any):Certificate|null => {
       , certIndex: row.certIndex
       , pot: potType 
       , rewards: row.rewards === null
-        ? null
+        ? {}
         : rewards };
   }
   default:

--- a/src/services/poolInfo.ts
+++ b/src/services/poolInfo.ts
@@ -24,6 +24,17 @@ interface PoolHistory {
     payload: Certificate | null; 
 }
 
+const latestMetadataQuery = `
+  select encode(pool_meta_data.hash, 'hex')
+     from pool_hash
+     join pool_update 
+          on pool_hash.id = pool_update.hash_id 
+     join pool_meta_data 
+          on pool_update.meta = pool_meta_data.id
+     where encode(pool_hash.hash, 'hex') = $1
+    order by pool_update.id desc limit 1;
+`;
+
 const poolHistoryQuery = `
   select row_to_json(combined_certificates) as "jsonCert"
        , block.epoch_no
@@ -35,45 +46,34 @@ const poolHistoryQuery = `
     on tx.id = combined_certificates."txId"
   join block
     on block.id = tx.block
-  where "poolHashKey" = (select distinct encode(pool_hash.hash,'hex') 
-                         from pool_hash 
-                         join pool_update 
-                           on pool_hash.id = pool_update.hash_id 
-                         join pool_meta_data 
-                           on pool_update.meta = pool_meta_data.id 
-                         where encode(pool_meta_data.hash, 'hex') = $1) 
-                           and ("jsType" = 'PoolRegistration' or "jsType" = 'PoolRetirement');
-`;
-
-const poolPledgeAddrQuery = `
-  select addr.hash 
-  from pool_hash 
-  join pool_update 
-    on pool_hash.id = pool_update.hash_id 
-  join stake_address addr 
-    on addr.id = pool_update.reward_addr_id 
-  join pool_meta_data 
-    on pool_update.meta = pool_meta_data.id 
-  where encode(pool_meta_data.hash, 'hex') = $1 order by pool_update.id desc limit 1;
+  where "poolHashKey" = $1;
 `;
 
 export const handlePoolInfo = (p: Pool) => async (req: Request, res: Response):Promise<void>=> { 
   if(!req.body.poolMetaDataHashes)
-    throw new Error ("No poolMetaDataHashes in body");
-  const hashes = req.body.poolMetaDataHashes;
+    throw new Error ("No poolIds in body");
+  const hashes = req.body.poolIds;
 
   if(!(hashes instanceof Array) || hashes.length > addressesRequestLimit)
-    throw new Error (` poolMetaDataHashes must have between 0 and ${addressesRequestLimit} items`);
+    throw new Error (` poolIds must have between 0 and ${addressesRequestLimit} items`);
    
   const ret:Dictionary<any> = {};
 
   for (const hash of hashes) {
-    if(hash.length !== 64){
-      throw new Error(`Recieved invalid pool metadata hash for SMASH: ${hash}`);
+    if(hash.length !== 56){
+      throw new Error(`Received invalid pool id: ${hash}`);
     }
-    let info = { pledge_address: null };
+    const metadataHashResp = await p.query(poolHistoryQuery, [latestMetadataQuery]);
+    if (metadataHashResp.rows.length === 0) {
+      ret[hash] = null;
+      continue;
+    }
+    const metadataHash = metadataHashResp.rows[0];
+
+
+    let info = null;
     try {
-      const endpointResponse = await axios.get(submissionEndpoint+hash); 
+      const endpointResponse = await axios.get(submissionEndpoint+metadataHash); 
       if(endpointResponse.status === 200){
         info = endpointResponse.data;
       }else{
@@ -82,12 +82,7 @@ export const handlePoolInfo = (p: Pool) => async (req: Request, res: Response):P
       console.log(`SMASH did not respond with hash ${hash}, giving error ${e}`);
     }
 
-    const dbHistory = await p.query(poolHistoryQuery, [hash]);
-    const dbPledgeAddr = await p.query(poolPledgeAddrQuery, [hash]);
-    
-    info.pledge_address = dbPledgeAddr.rows.length > 0
-      ? dbPledgeAddr.rows[0].hash.toString("hex")
-      : null;
+    const dbHistory = await p.query(poolHistoryQuery, [metadataHash]);
 
     const history = dbHistory.rows.map( (row: any) => ({
       epoch: row.epoch_no
@@ -96,9 +91,10 @@ export const handlePoolInfo = (p: Pool) => async (req: Request, res: Response):P
       , cert_ordinal: row.certIndex
       , payload: rowToCertificate(row.jsonCert)
     }));
-    ret[hash] = { info: info
-      , history: history};
-
+    ret[hash] = {
+      info: info,
+      history: history
+    };
   }
 
   res.send(ret);

--- a/src/services/poolInfo.ts
+++ b/src/services/poolInfo.ts
@@ -71,7 +71,7 @@ export const handlePoolInfo = (p: Pool) => async (req: Request, res: Response):P
     const metadataHash = metadataHashResp.rows[0];
 
 
-    let info = null;
+    let info = {};
     try {
       const endpointResponse = await axios.get(submissionEndpoint+metadataHash); 
       if(endpointResponse.status === 200){

--- a/tests/getAccountState.test.ts
+++ b/tests/getAccountState.test.ts
@@ -1,9 +1,6 @@
 import axios from "axios";
 import { expect } from "chai";
-import { resultsForSingleHistory } from "./dataSingleHistory";
-import { config, Config } from "./config";
-import { Certificate, TransactionFrag } from "../src/Transactions/types";
-import * as R from "ramda";
+import { config, } from "./config";
 
 const endpoint = config.apiUrl;
 const testableUri = endpoint + "getAccountState";

--- a/tests/getPoolInfo.test.ts
+++ b/tests/getPoolInfo.test.ts
@@ -1,0 +1,38 @@
+import axios from "axios";
+import { expect } from "chai";
+import { config, } from "./config";
+
+const endpoint = config.apiUrl;
+const testableUri = endpoint + "getPoolInfo";
+
+const realPoolId = "1b268f4cba3faa7e36d8a0cc4adca2096fb856119412ee7330f692b5";
+const fakePoolId = "00000000000000000000000000000000000000000000000000000001";
+const privatePool = "b1fe7ac3669604156c20dcfc08355197af5637c37750d862039670c4";
+
+describe("/getPoolInfo", function() {
+  it("should return 0 rewards for addresses that have withdrawn everything", async() => {
+    const result = await axios({method: "post", url: testableUri, data: {poolIds: [realPoolId]}});
+    expect(result.data).to.have.property(realPoolId);
+
+    expect(result.data[realPoolId]).to.have.property("info");
+    expect(result.data[realPoolId].info).to.not.be.equal(null);
+
+    expect(result.data[realPoolId]).to.have.property("history");
+    expect(result.data[realPoolId].history).to.have.lengthOf.above(0);
+  });
+  it("should return null info for private pool id", async() => {
+    const result = await axios({method: "post", url: testableUri, data: {poolIds: [privatePool]}});
+    expect(result.data).to.have.property(privatePool);
+
+    expect(result.data[realPoolId]).to.have.property("info");
+    expect(result.data[realPoolId].info).to.be.equal(null);
+
+    expect(result.data[realPoolId]).to.have.property("history");
+    expect(result.data[realPoolId].history).to.have.lengthOf.above(0);
+  });
+  it("should return null for pool id that doesn't exist on chain", async() => {
+    const result = await axios({method: "post", url: testableUri, data: {poolIds: [fakePoolId]}});
+    expect(result.data).to.have.property(fakePoolId);
+    expect(result.data[fakePoolId]).to.be.a("null");
+  });
+});

--- a/tests/getPoolInfo.test.ts
+++ b/tests/getPoolInfo.test.ts
@@ -5,13 +5,14 @@ import { config, } from "./config";
 const endpoint = config.apiUrl;
 const testableUri = endpoint + "getPoolInfo";
 
-const realPoolId = "1b268f4cba3faa7e36d8a0cc4adca2096fb856119412ee7330f692b5";
+const realPoolId = "1b268f4cba3faa7e36d8a0cc4adca2096fb856119412ee7330f692b5"; // note: this pool has changed its metadata at least once
 const fakePoolId = "00000000000000000000000000000000000000000000000000000001";
 const privatePool = "b1fe7ac3669604156c20dcfc08355197af5637c37750d862039670c4";
 
 describe("/getPoolInfo", function() {
-  it("should return 0 rewards for addresses that have withdrawn everything", async() => {
+  it("should return information about a pool that has metadata available", async() => {
     const result = await axios({method: "post", url: testableUri, data: {poolIds: [realPoolId]}});
+    console.log(result.data);
     expect(result.data).to.have.property(realPoolId);
 
     expect(result.data[realPoolId]).to.have.property("info");
@@ -24,11 +25,11 @@ describe("/getPoolInfo", function() {
     const result = await axios({method: "post", url: testableUri, data: {poolIds: [privatePool]}});
     expect(result.data).to.have.property(privatePool);
 
-    expect(result.data[realPoolId]).to.have.property("info");
-    expect(result.data[realPoolId].info).to.be.equal(null);
+    expect(result.data[privatePool]).to.have.property("info");
+    expect(result.data[privatePool].info).to.be.empty;
 
-    expect(result.data[realPoolId]).to.have.property("history");
-    expect(result.data[realPoolId].history).to.have.lengthOf.above(0);
+    expect(result.data[privatePool]).to.have.property("history");
+    expect(result.data[privatePool].history).to.have.lengthOf.above(0);
   });
   it("should return null for pool id that doesn't exist on chain", async() => {
     const result = await axios({method: "post", url: testableUri, data: {poolIds: [fakePoolId]}});


### PR DESCRIPTION
Few things changes

1) getPoolInfo takes pool ids instead of metadata hashes. Yoroi can't know metadata hashes -- only pool ids
2) I remove `pledge_address` from the poolInfo response. This is because now that we have the `history` field, you can get the pledge address from the history instead.
3) Return `{}` instead of `null` for empty `rewards` certificate. This is easier to work with (note: we never need to ask "is this empty", so not a big deal to return an empty object)
4) Fix withdrawals. A mistake in the join caused all ITN rewards to not show up in the result
