### PR TITLE
mod - tx history endpoint accepts payment creds as well as addresses.

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,6 +201,10 @@ Up to 50 addresses in the request
 
 ```js
 {
+  // addresses may contain several different things.
+  // 1. For reward addresses, this field accepts the hex (as a string)
+  // 2. For Ptr / enterprise / base addresses, this field will accept the hex of the _payment key_ as a string.
+  // 3. For Byone, use the Ae2/Dd address.
   addresses: Array<string>,
   // omitting "after" means you query starting from the genesis block
   after?: {

--- a/tests/txHistory.test.ts
+++ b/tests/txHistory.test.ts
@@ -100,6 +100,12 @@ const dataShelleyCerts = {
   , untilBlock: "d6f6cd7101ce4fa80f7d7fe78745d2ca404705f58247320bc2cef975e7574939"
 };
 
+const dataPaymentCreds = {
+  addresses: ["x9566a8f301fb8a046e44557bb38dfb9080a1213f17f200dcd3808169"
+             ,"211c082781577c6b8a4832d29011baab323947e59fbd6ec8995b6c5a"]
+  , untilBlock: "d6f6cd7101ce4fa80f7d7fe78745d2ca404705f58247320bc2cef975e7574939"
+};
+
 const dataRewardAddresses = {
   addresses: ["e10e5b086df87a2a0c5c398b41d413f84176c527da5e5cb641f4598844"
              ,"e1279cf18e075b222f093746f4f9cad980fd3fc5fcc5f69decef4f9ee9"
@@ -222,6 +228,10 @@ describe("/txs/history", function() {
     expect(result.data[0].outputs[0].amount).to.be.eql("3168639578");
     expect(result.data[0].outputs[1].address).to.be.eql("Ae2tdPwUPEYynjShTL8D2L2GGggTH3AGtMteb7r65oLar1vzZ4JPfxob4b8");
     expect(result.data[0].outputs[1].amount).to.be.eql("98000000");
+  });
+  it("should get txs by payment creds", async() => {
+    const result = await axios.post(testableUri, dataPaymentCreds);
+    expect(result.data).to.not.be.empty;
   });
   it("should get sensible shelley certificates", async() => {
     const result = await axios.post(testableUri, dataShelleyCerts);


### PR DESCRIPTION
this requires commit e30563ec55b52ceeb6df48d89286a879000b0305 from cardano-db-sync
without this commit this code is not performant.

normally, you would think that we could do something like
	...
	WHERE ...
  	   OR encode(payment_cred,'hex') = ANY(($1)::varchar array)
	...
But that wouldn't work unless we put a function index on the tx_out.payment_cred
column, and I think that is unwise.
So we transform from string to bytea in js-land.
Now, bytea from psql become Buffer in js-land, so you would naively think that
a Buffer is what we need to send back.  But the naive thought is wrong.
Rather the pg library will convert a string it sees that starts with a \x
(as byteas appear in the console in psql).  So we must convert our strings thus.
But to avoid errors we will need to filter out any strings that aren't actually
a hex.
this is where the more complicated code comes from.