### PR TITLE
index: adding current time to /status endpoint

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -282,7 +282,7 @@ const getStatus = async (req: Request, res:  Response) => {
       }
     }
   }
-  res.send({ isServerOk: true, isMaintenance: false }); 
+  res.send({ isServerOk: true, isMaintenance: false, serverTime: Date.now() });
 };
 
 const routes : Route[] = [ { path: "/v2/bestblock"


### PR DESCRIPTION
Adding current backend unix time to the api status endpoint. Keep in mind this is in ms, divide by 1000 for seconds.