### PR TITLE
bugfix - decode tx_hash from the database from hex into string.

### DIFF
--- a/src/services/utxoForAddress.ts
+++ b/src/services/utxoForAddress.ts
@@ -7,7 +7,7 @@ import { assertNever, contentTypeHeaders, graphqlEndpoint, isHex, UtilEither, va
 
 const utxoForAddressQuery = `
   select tx_out.address
-       , tx.hash
+       , encode(tx.hash,'hex') as hash
        , tx_out.index
        , tx_out.value
        , block.block_no as "blockNumber"

--- a/tests/utxoForAddresses.test.ts
+++ b/tests/utxoForAddresses.test.ts
@@ -30,6 +30,8 @@ describe("/txs/utxoForAddresses", function() {
     expect(result.data[0]).to.have.property("amount");
     expect(result.data[0]).to.have.property("block_num");
     expect(result.data[0]).to.have.property("tx_index");
+    expect(result.data[0]).to.have.property("tx_hash");
+    expect(result.data[0].tx_hash).to.be.an("string");
     expect(result.data[0].amount).to.be.equal("200000");
     expect(result.data[0].block_num).to.be.equal(322087);
     expect(result.data[0].tx_index).to.be.equal(1);


### PR DESCRIPTION
introduced in https://github.com/Emurgo/yoroi-graphql-migration-backend/pull/34.

When this endpoint used graphql, hasura and co took care of the decoding.
I forgot to do this when I moved it to sql to support payment creds.