### PR TITLE
Bump serialization lib

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -31,9 +31,9 @@
       }
     },
     "@emurgo/cardano-serialization-lib-nodejs": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@emurgo/cardano-serialization-lib-nodejs/-/cardano-serialization-lib-nodejs-2.0.0.tgz",
-      "integrity": "sha512-JZapVXweLo2MEpXtlonES7BrvpzNPGZdOWL2QUAyd30tC30I75ZpTiLyBKeVYBj3yvAV1BwReQpvcO+PsXWBog=="
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@emurgo/cardano-serialization-lib-nodejs/-/cardano-serialization-lib-nodejs-3.0.0.tgz",
+      "integrity": "sha512-MlrViFSPOtyCPnbWTQK2Dus9aYBtgzuclzDcoTqgkrEkeXrER4sBZ7ogniQm+AkWqkAJnX7YBAzQ+95UH2LwMw=="
     },
     "@opencensus/core": {
       "version": "0.0.9",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   "author": "",
   "license": "MIT",
   "dependencies": {
-    "@emurgo/cardano-serialization-lib-nodejs": "^2.0.0",
+    "@emurgo/cardano-serialization-lib-nodejs": "^3.0.0",
     "@types/chai": "^4.2.11",
     "@types/compression": "^1.7.0",
     "@types/cors": "^2.8.6",

--- a/src/services/accountState.ts
+++ b/src/services/accountState.ts
@@ -36,7 +36,7 @@ const queryCardanoCli = async (address: string /* hex-encoded string */): Promis
   let bech32Addr;
   try {
     const wasmAddr = Address.from_bytes(Buffer.from(address, "hex"));
-    bech32Addr = wasmAddr.to_bech32("stake");
+    bech32Addr = wasmAddr.to_bech32();
     wasmAddr.free();
   } catch (_e) {
     console.log(`invalid address ${address}`);


### PR DESCRIPTION
The latest version of serialization-lib implements CIP5 which should automatically be picking the correct bech32 prefix.