### PR TITLE
Rework payment key support

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ npm run test
 
   ```js
   {
+    // bech32 address for strict match. hex-encoded address for matching on the payment key
     addresses: Array<string>
   }
   ```
@@ -205,6 +206,7 @@ npm run test
 
   ```js
   {
+    // bech32 address for strict match. hex-encoded address for matching on the payment key
     addresses: Array<string>
   }
   ```
@@ -238,8 +240,9 @@ npm run test
   {
     // addresses may contain several different things.
     // 1. For reward addresses, this field accepts the hex (as a string)
-    // 2. For Ptr / enterprise / base addresses, this field will accept the hex of the _payment key_ as a string.
-    // 3. For Byone, use the Ae2/Dd address.
+    // 2. Bech32 addresses will strictly match the address passed in
+    // 3. hex-encoded addresses will match on any address with the same payment key
+    // 4. For Byron, use the Ae2/Dd address.
     addresses: Array<string>,
     // omitting "after" means you query starting from the genesis block
     after?: {

--- a/src/services/filterUsedAddress.ts
+++ b/src/services/filterUsedAddress.ts
@@ -1,8 +1,12 @@
 import { Pool } from "pg";
 import { Request, Response } from "express";
+import {
+  Address,
+  ByronAddress,
+} from "@emurgo/cardano-serialization-lib-nodejs";
 
 import config from "config";
-import { assertNever, getCardanoSpendingKeyHash, isHex, validateAddressesReq } from "../utils";
+import { assertNever, validateAddressesReq, getSpendingKeyHash } from "../utils";
 
 const baseQuery = `
   select ( select json_agg((address)) 
@@ -27,46 +31,118 @@ const filterByPaymentCredQuery = `
 
 const addressesRequestLimit:number = config.get("server.addressRequestLimit");
 
+export function getAddressesByType(addresses: string[]): {
+  /**
+   * note: we keep track of explicit bech32 addresses
+   * since it's possible somebody wants the tx history for a specific address
+   * and not the tx history for the payment key of the address
+   */
+  legacyAddr: string[],
+  bech32: string[],
+  paymentKeyMap: Map<string, Set<string>>,
+} {
+  const legacyAddr = [];
+  const bech32 = [];
+  const paymentKeyMap = new Map();
+  for (const address of addresses) {
+    // 1) Check if it's a Byron-era address
+    if (ByronAddress.is_valid(address)) {
+      legacyAddr.push(address);
+      continue;
+    }
+    // 2) check if it's a valid bech32 address
+    try {
+      const wasmBech32 = Address.from_bech32(address);
+      bech32.push(address);
+      wasmBech32.free();
+      continue;
+    } catch (_e) {
+      // silently discard any non-valid Cardano addresses
+    }
+    try {
+      const wasmAddr = Address.from_bytes(
+        Buffer.from(address, "hex")
+      );
+      const spendingKeyHash = getSpendingKeyHash(wasmAddr);
+      if (spendingKeyHash != null) {
+        const addressesForKey = paymentKeyMap.get(spendingKeyHash) ?? new Set();
+        addressesForKey.add(address);
+        paymentKeyMap.set(spendingKeyHash, addressesForKey);
+      }
+      wasmAddr.free();
+      continue;
+    } catch (_e) {
+      // silently discard any non-valid Cardano addresses
+    }
+  }
+
+  return {
+    legacyAddr,
+    bech32,
+    paymentKeyMap,
+  };
+}
+
+
 export const filterUsedAddresses = (pool : Pool) => async (req: Request, res: Response) => {
   if(!req.body || !req.body.addresses) {
     throw new Error("no addresses in request body.");
     return;
   }
   const verifiedAddrs = validateAddressesReq(addressesRequestLimit, req.body.addresses);
+  const addressTypes = getAddressesByType(req.body.addresses);
   switch(verifiedAddrs.kind){
   case "ok": {
-    const paymentCreds = new Set(verifiedAddrs.value.filter(isHex).map((s:string) => `\\x${s}`));
-    const addresses = new Set(verifiedAddrs.value.filter(addr => !isHex(addr)));
+    const regularAddresses = [
+      ...addressTypes.legacyAddr,
+      ...addressTypes.bech32,
+    ];
 
     const result: Set<string> = new Set();
 
-    if (paymentCreds.size > 0) {
+    if (addressTypes.paymentKeyMap.size > 0) {
       // 1) Get all transactions that contain one of these payment keys
-      const queryResult = await pool.query(filterByPaymentCredQuery, [Array.from(paymentCreds)]);
+      const queryResult = await pool.query(
+        filterByPaymentCredQuery,
+        [Array
+          .from(addressTypes.paymentKeyMap.keys())
+          .map(addr => `\\x${addr}`)
+        ]
+      );
       // 2) get all the addresses inside these transactions
       const addressesInTxs = queryResult.rows.flatMap( tx => [tx.inputs, tx.outputs]).flat();
+      console.log(queryResult.rows);
+      console.log(Array.from(addressTypes.paymentKeyMap.keys()));
       // 3) get the payment credential for each address in the transaction
       const keysInTxs: Array<string> = addressesInTxs.reduce(
         (arr, next) => {
-          const paymentCred = getCardanoSpendingKeyHash(next);
-          if (paymentCred != null) arr.push(paymentCred);
+          try {
+            const wasmAddr = Address.from_bech32(next);
+            const paymentCred = getSpendingKeyHash(wasmAddr);
+            if (paymentCred != null) arr.push(paymentCred);
+            wasmAddr.free();
+          } catch (_e) {
+            // silently discard any non-valid Cardano addresses
+          }
+          
           return arr;
         },
         ([] as Array<string>)
       );
       // 4) filter addresses to the ones we care about for this filterUsed query
       keysInTxs
-        .filter(addr => paymentCreds.has(`\\x${addr}`))
+        .flatMap(addr => Array.from(addressTypes.paymentKeyMap.get(addr) ?? []))
         .forEach(addr => result.add(addr));
     }
-    if (addresses.size > 0) {
+    if (regularAddresses.length > 0) {
       // 1) Get all transactions that contain one of these addresses
-      const queryResult = await pool.query(filterByAddressQuery, [Array.from(addresses)]);
+      const queryResult = await pool.query(filterByAddressQuery, [regularAddresses]);
       // 2) get all the addresses inside these transactions
       const addressesInTxs = queryResult.rows.flatMap( tx => [tx.inputs, tx.outputs]).flat();
       // 3) filter addresses to the ones we care about for this filterUsed query
+      const addressSet = new Set(regularAddresses);
       addressesInTxs
-        .filter(addr => addresses.has(addr))
+        .filter(addr => addressSet.has(addr))
         .forEach(addr => result.add(addr));
     }
     res.send([...result]);

--- a/src/services/utxoSumForAddress.ts
+++ b/src/services/utxoSumForAddress.ts
@@ -3,6 +3,7 @@ import axios from "axios";
 import { contentTypeHeaders, graphqlEndpoint, UtilEither} from "../utils";
 
 export const askUtxoSumForAddresses = async (addresses: string[]): Promise<UtilEither<string>> => {
+  // TODO: support for payment keys
   const query = `
             query UtxoForAddresses($addresses: [String]) {
               utxos_aggregate(where: {
@@ -28,7 +29,7 @@ export const askUtxoSumForAddresses = async (addresses: string[]): Promise<UtilE
        && "value" in ret.data.data.utxos_aggregate.aggregate.sum)
     return { kind: "ok", value: ret.data.data.utxos_aggregate.aggregate.sum.value };
   else
-    return { kind: "error", errMsg: "utxoSumforAddresses, could not unstand graphql response."};
+    return { kind: "error", errMsg: "utxoSumforAddresses, could not understand graphql response."};
 
 
 };

--- a/tests/filterUsedAddresses.test.ts
+++ b/tests/filterUsedAddresses.test.ts
@@ -21,11 +21,11 @@ const expectedResult = [
 ];
 
 const paymentCreds = [
-  "211c082781577c6b8a4832d29011baab323947e59fbd6ec8995b6c5a",
-  "0000082781577c6b8a4832d29011baab323947e59fbd6ec8995b6c5a",
+  "61211c082781577c6b8a4832d29011baab323947e59fbd6ec8995b6c5a",
+  "610000082781577c6b8a4832d29011baab323947e59fbd6ec8995b6c5a",
 ];
 const expectedPaymentCredResult = [
-  "211c082781577c6b8a4832d29011baab323947e59fbd6ec8995b6c5a",
+  "61211c082781577c6b8a4832d29011baab323947e59fbd6ec8995b6c5a",
 ];
 
 describe("/addresses/filterUsed", function() {
@@ -35,7 +35,7 @@ describe("/addresses/filterUsed", function() {
     expect(result.data).to.be.an("array");
     expect(result.data.sort()).to.be.eql(expectedResult.sort());
   });
-  it("can handle payment creds", async function () {
+  it("can handle enterprise addresses", async function () {
     const postData = { addresses: paymentCreds };
     const result = await axios.post(endpoint+"v2/addresses/filterUsed", postData);
     expect(result.data).to.be.an("array");

--- a/tests/txHistory.test.ts
+++ b/tests/txHistory.test.ts
@@ -97,15 +97,9 @@ const dataTxOrdering = {
 const dataShelleyCerts = {
   addresses: [
      "addr1q9ya8v4pe33nlkgftyd70nhhp407pvnjjcsddhf64sh9gegwtvyxm7r69gx9cwvtg82p87zpwmzj0kj7tjmyraze3pzqe6zxzv"
-     // enterprise address
+      // enterprise address
     ,"addr1v8vqle5aa50ljr6pu5ndqve29luch29qmpwwhz2pk5tcggqn3q8mu"
   ]
-  , untilBlock: "d6f6cd7101ce4fa80f7d7fe78745d2ca404705f58247320bc2cef975e7574939"
-};
-
-const dataPaymentCreds = {
-  addresses: ["x9566a8f301fb8a046e44557bb38dfb9080a1213f17f200dcd3808169"
-    ,"211c082781577c6b8a4832d29011baab323947e59fbd6ec8995b6c5a"]
   , untilBlock: "d6f6cd7101ce4fa80f7d7fe78745d2ca404705f58247320bc2cef975e7574939"
 };
 
@@ -357,9 +351,15 @@ describe("/txs/history", function() {
     expect(result.data[0].outputs[1].address).to.be.eql("Ae2tdPwUPEYynjShTL8D2L2GGggTH3AGtMteb7r65oLar1vzZ4JPfxob4b8");
     expect(result.data[0].outputs[1].amount).to.be.eql("98000000");
   });
-  it("should get txs by payment creds", async() => {
-    const result = await axios.post(testableUri, dataPaymentCreds);
-    expect(result.data).to.not.be.empty;
+  it("should get txs by enterprise address", async() => {
+    const result = await axios.post(testableUri, {
+      addresses: [
+        "61211c082781577c6b8a4832d29011baab323947e59fbd6ec8995b6c5a"
+      ]
+      , untilBlock: "d6f6cd7101ce4fa80f7d7fe78745d2ca404705f58247320bc2cef975e7574939"
+    });
+    expect(result.data).to.have.lengthOf(1);
+    expect(result.data[0].hash).to.equal("92bdc4f35fd9b363a4eac47898148fd1816efd4260d71e8251ca80dbb7a39ca3");
   });
   it("should get sensible shelley certificates", async() => {
     const result = await axios.post(testableUri, dataShelleyCerts);

--- a/tests/utxoForAddresses.test.ts
+++ b/tests/utxoForAddresses.test.ts
@@ -7,7 +7,8 @@ const endpoint = config.apiUrl;
 const s = should();
 
 const add1 = "DdzFFzCqrht4wFnWC5TJA5UUVE54JC9xZWq589iKyCrWa6hek3KKevyaXzQt6FsdunbkZGzBFQhwZi1MDpijwRoC7kj1MkEPh2Uu5Ssz";
-const paymentCred = "5c619e192407b2e972f04f0dda7c52aa8013d45ee7ba69d57041cad0";
+
+const enterpriseAddresses = "615c619e192407b2e972f04f0dda7c52aa8013d45ee7ba69d57041cad0";
 
 const addresses = 
     [ "DdzFFzCqrht4wFnWC5TJA5UUVE54JC9xZWq589iKyCrWa6hek3KKevyaXzQt6FsdunbkZGzBFQhwZi1MDpijwRoC7kj1MkEPh2Uu5Ssz",
@@ -36,8 +37,8 @@ describe("/txs/utxoForAddresses", function() {
     expect(result.data[0].block_num).to.be.equal(322087);
     expect(result.data[0].tx_index).to.be.equal(1);
   });
-  it("paymentCred returns something non-trivial", async function() {
-    const postData = { addresses: [paymentCred] };
+  it("enterprise addresses returns something non-trivial", async function() {
+    const postData = { addresses: [enterpriseAddresses] };
     const result = await axios.post(endpoint+"txs/utxoForAddresses", postData);
     expect(result.data[0]).to.have.property("amount");
     expect(result.data[0]).to.have.property("block_num");


### PR DESCRIPTION
`filterUsed`, `history` and `utxoForAddresses` used to support payment keys by passing in the payment key hash directly

However, this doesn't really scale well into the future since payment keys have no particular structure (just random bytes), so there would be no way to expand our API to support any future key types. So instead, I changed all the endpoints to accept hex-encoded addresses (notably enterprise addresses) instead of raw payment keys to provide the loose matching support.