### PR TITLE
Use CIP5 for queries

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,14 @@ npm run test
 
 ## API
 
+For addresses, refer to [CIP5](https://github.com/cardano-foundation/CIPs/tree/master/CIP5) for how they should be encoded. Notably, we support
+
+- `addr` & `addr_test`
+- `stake` & `stake_test`
+- `addr_vkh`
+
+We recommend querying using payment key hashes (`addr_vkh`) when possible (otherwise you may miss addresses for a wallet such as mangled based addresses or other address types like pointer addresses)
+
 <details>
   <summary>api/txs/utxoForAddresses</summary>
   Input
@@ -62,7 +70,7 @@ npm run test
 
   ```js
   {
-    // bech32 address for strict match. hex-encoded address for matching on the payment key
+    // byron addresses, bech32 address, bech32 stake addresses or addr_vkh
     addresses: Array<string>
   }
   ```
@@ -86,7 +94,8 @@ npm run test
 
   ```js
   {
-    addresses: Array<string> // hex of reward stake addresses
+    // bech32 stake address
+    addresses: Array<string>
   }
   ```
 
@@ -109,7 +118,8 @@ npm run test
 
   ```js
   {
-    addresses: Array<string> // hex of reward stake addresses
+    // bech32 stake addresses
+    addresses: Array<string>
   }
   ```
 
@@ -132,7 +142,8 @@ npm run test
 
   ```js
   {
-    addresses: Array<string> // hex of reward stake addresses
+    // bech32 stake address
+    addresses: Array<string>
   }
   ```
 
@@ -153,7 +164,7 @@ npm run test
 
   ```js
   {
-    poolIds: Array<string> // operator key
+    poolIds: Array<string> // operator key (pool id)
   }
   ```
 
@@ -206,7 +217,7 @@ npm run test
 
   ```js
   {
-    // bech32 address for strict match. hex-encoded address for matching on the payment key
+    // byron addresses, bech32 address or addr_vkh
     addresses: Array<string>
   }
   ```
@@ -238,11 +249,7 @@ npm run test
 
   ```js
   {
-    // addresses may contain several different things.
-    // 1. For reward addresses, this field accepts the hex (as a string)
-    // 2. Bech32 addresses will strictly match the address passed in
-    // 3. hex-encoded addresses will match on any address with the same payment key
-    // 4. For Byron, use the Ae2/Dd address.
+    // byron addresses, bech32 address, bech32 stake addresses or addr_vkh
     addresses: Array<string>,
     // omitting "after" means you query starting from the genesis block
     after?: {

--- a/src/utils/cip5.ts
+++ b/src/utils/cip5.ts
@@ -1,0 +1,8 @@
+// prefixes based on CIP5 https://github.com/cardano-foundation/CIPs/tree/master/CIP5
+export const Prefixes = Object.freeze({
+  ADDR: "addr",
+  ADDR_TEST: "addr_test",
+  STAKE: "stake",
+  STAKE_TEST: "stake_test",
+  PAYMENT_KEY_HASH: "addr_vkh",
+});

--- a/tests/filterUsedAddresses.test.ts
+++ b/tests/filterUsedAddresses.test.ts
@@ -1,6 +1,8 @@
 import axios from "axios";
 import { expect } from "chai";
 import { config, } from "./config";
+import { encode, toWords, } from "bech32";
+import { Prefixes } from "../src/utils/cip5";
 
 const endpoint = config.apiUrl;
 
@@ -21,11 +23,11 @@ const expectedResult = [
 ];
 
 const paymentCreds = [
-  "61211c082781577c6b8a4832d29011baab323947e59fbd6ec8995b6c5a",
-  "610000082781577c6b8a4832d29011baab323947e59fbd6ec8995b6c5a",
+  encode(Prefixes.PAYMENT_KEY_HASH, toWords(Buffer.from("211c082781577c6b8a4832d29011baab323947e59fbd6ec8995b6c5a", "hex"))),
+  encode(Prefixes.PAYMENT_KEY_HASH, toWords(Buffer.from("0000082781577c6b8a4832d29011baab323947e59fbd6ec8995b6c5a", "hex"))),
 ];
 const expectedPaymentCredResult = [
-  "61211c082781577c6b8a4832d29011baab323947e59fbd6ec8995b6c5a",
+  encode(Prefixes.PAYMENT_KEY_HASH, toWords(Buffer.from("211c082781577c6b8a4832d29011baab323947e59fbd6ec8995b6c5a", "hex"))),
 ];
 
 describe("/addresses/filterUsed", function() {

--- a/tests/utxoForAddresses.test.ts
+++ b/tests/utxoForAddresses.test.ts
@@ -1,5 +1,7 @@
 import axios from "axios";
 import { expect, should } from "chai";
+import { encode, toWords, } from "bech32";
+import { Prefixes } from "../src/utils/cip5";
 
 import { config, } from "./config";
 
@@ -8,7 +10,8 @@ const s = should();
 
 const add1 = "DdzFFzCqrht4wFnWC5TJA5UUVE54JC9xZWq589iKyCrWa6hek3KKevyaXzQt6FsdunbkZGzBFQhwZi1MDpijwRoC7kj1MkEPh2Uu5Ssz";
 
-const enterpriseAddresses = "615c619e192407b2e972f04f0dda7c52aa8013d45ee7ba69d57041cad0";
+
+const enterpriseAddresses = encode(Prefixes.PAYMENT_KEY_HASH, toWords(Buffer.from("5c619e192407b2e972f04f0dda7c52aa8013d45ee7ba69d57041cad0", "hex")));
 
 const addresses = 
     [ "DdzFFzCqrht4wFnWC5TJA5UUVE54JC9xZWq589iKyCrWa6hek3KKevyaXzQt6FsdunbkZGzBFQhwZi1MDpijwRoC7kj1MkEPh2Uu5Ssz",


### PR DESCRIPTION
This switches the endpoints to use [CIP5](https://github.com/cardano-foundation/CIPs/tree/master/CIP5) for both payment key queries and stake queries (we already used it for regular addresses)

For backwards compatibility, we still allow stake keys to be passed in as hex-string, but we can remove this in a future version after Yoroi Extension & Yoroi Mobile have updated.