### PR TITLE
refactor for cardano-db-sync 6.0.0

### DIFF
--- a/src/Transactions/certificates.ts
+++ b/src/Transactions/certificates.ts
@@ -93,7 +93,7 @@ select 'PoolRegistration' as "jsType"
            -- with the hashkey of the pool operator. looking through Insert.hs,
            -- it is clear that there is a hash that's identified with the stake
            -- pool.  it is this one!
-     , encode(pool.vrf_key,'hex') as "poolParamsVrfKeyHash"
+     , encode(pool.vrf_key_hash,'hex') as "poolParamsVrfKeyHash"
      , pool.pledge as "poolParamsPledge"
      , pool.fixed_cost as "poolParamsCost"
      , pool.margin as "poolParamsMargin"
@@ -124,7 +124,7 @@ join pool_hash
 join stake_address as addr
   on addr.id = pool.reward_addr_id
 left join pool_meta_data as pool_meta
-  on pool_meta.id = pool.meta
+  on pool_meta.id = pool.meta_id
 
 UNION ALL
   

--- a/src/services/poolInfo.ts
+++ b/src/services/poolInfo.ts
@@ -30,7 +30,7 @@ const latestMetadataQuery = `
      join pool_update 
           on pool_hash.id = pool_update.hash_id 
      join pool_meta_data 
-          on pool_update.meta = pool_meta_data.id
+          on pool_update.meta_id = pool_meta_data.id
      where encode(pool_hash.hash_raw, 'hex') = $1
     order by pool_update.id desc limit 1;
 `;
@@ -45,7 +45,7 @@ const poolHistoryQuery = `
   join tx
     on tx.id = combined_certificates."txId"
   join block
-    on block.id = tx.block
+    on block.id = tx.block_id
   where "poolHashKey" = $1
     and ("jsType" = 'PoolRegistration' or "jsType" = 'PoolRetirement');
 `;

--- a/src/services/regHistory.ts
+++ b/src/services/regHistory.ts
@@ -15,7 +15,7 @@ const regHistoryQuery = `
   from stake_registration cc 
   join stake_address sa on cc.addr_id = sa.id 
   join tx on cc.tx_id = tx.id 
-  join block on tx.block=block.id 
+  join block on tx.block_id=block.id 
   where sa.hash_raw = any(($1)::bytea array) 
   union 
   select block.slot_no as "slotNo"
@@ -25,7 +25,7 @@ const regHistoryQuery = `
        , 'StakeDeregistration' as "certType"
   from stake_deregistration cc 
   join stake_address sa on cc.addr_id = sa.id 
-  join tx on cc.tx_id = tx.id join block on tx.block=block.id 
+  join tx on cc.tx_id = tx.id join block on tx.block_id=block.id 
   where sa.hash_raw = any(($1)::bytea array) 
 `;
 

--- a/src/services/transactionHistory.ts
+++ b/src/services/transactionHistory.ts
@@ -137,7 +137,7 @@ const askTransactionSqlQuery = `
     on hashes.hash = tx.hash
 
   JOIN block
-    on block.id = tx.block
+    on block.id = tx.block_id
 
   LEFT JOIN pool_meta_data 
     on tx.id = pool_meta_data.registered_tx_id 
@@ -331,7 +331,7 @@ export const askBlockNumByTxHash = async (hash : string|undefined): Promise<Util
 
 export const askBlockNumByHash = async (hash : string) : Promise<UtilEither<number>> => {
   const query = `
-            query BlockNumByHash($id: Hash32HexString!) {
+            query BlockNumByHash($id: Hash32Hex!) {
               blocks(
                 where: {
                   hash: {

--- a/src/services/utxoForAddress.ts
+++ b/src/services/utxoForAddress.ts
@@ -17,7 +17,7 @@ const utxoForAddressQuery = `
     ON tx_out.tx_id = tx_in.tx_out_id
    AND tx_out.index::smallint = tx_in.tx_out_index::smallint
   JOIN block
-    on block.id = tx.block
+    on block.id = tx.block_id
   WHERE tx_in.tx_in_id IS NULL
     and (   tx_out.address = any(($1)::varchar array) 
          or tx_out.payment_cred = any(($2)::bytea array));


### PR DESCRIPTION
Updates to make the backend compatible with `cardano-db-sync release/6.0.x 6187081a7ea66954c86094578bd37e01bca8aaec` and `cardano-graphql master 8226d69b509e070afca85a090fe7f74deacfa61c`.