### PR TITLE
Add tx metadata support

### DIFF
--- a/src/services/transactionHistory.ts
+++ b/src/services/transactionHistory.ts
@@ -97,6 +97,9 @@ const askTransactionSqlQuery = `
     )
   select tx.hash
        , tx.fee
+       , case when tx_metadata.bytes is null then null
+              else encode(tx_metadata.bytes,'hex') end
+          as "metadata"
        , tx.block_index as "txIndex"
        , block.block_no as "blockNumber"
        , block.hash as "blockHash"
@@ -132,6 +135,9 @@ const askTransactionSqlQuery = `
           where "txId" = tx.id) as certificates
                             
   from tx
+
+  LEFT OUTER JOIN tx_metadata
+    on tx_metadata.tx_id = tx.id
 
   JOIN hashes
     on hashes.hash = tx.hash
@@ -254,7 +260,7 @@ export const askTransactionHistory = async (
     return { hash: row.hash.toString("hex")
       , block: blockFrag
       , fee: row.fee.toString()
-      , metadata: null // TODO
+      , metadata: row.metadata
       , includedAt: row.includedAt
       , inputs: inputs
       , outputs: outputs

--- a/tests/txHistory.test.ts
+++ b/tests/txHistory.test.ts
@@ -473,4 +473,18 @@ describe("/txs/history", function() {
       expect(result.data[0].certificates[0].kind).to.equal("PoolRegistration");
     }
   });
+  it("Get metadata for transaction", async() => {
+    const result = await axios.post(testableUri, {
+      addresses: [
+        encode(Prefixes.PAYMENT_KEY_HASH, toWords(Buffer.from("69f6f57453031d04bd71a08cd3f31e7d61bfa939037f0e547de850e3", "hex")))
+      ]
+      , untilBlock: "d9038b728b997566b4b5fd2686ed2268505f50c8faa1292837fede6ef42cdab5"
+      , after: {
+          tx: "0e06078128b5126c77cf6ffe68eab7d0d51423cba84f24d34c433752ff0c843b"
+        , block: "7b483248865efe366af230a68952340ec2a5868433a3323abfff433699997175"
+      }
+    });
+    expect(result.data).to.have.lengthOf(1);
+    expect(result.data[0].metadata).to.equal("a100a16b436f6d62696e6174696f6e8601010101010c");
+  });
 });


### PR DESCRIPTION
Adds tx metadata support based on https://github.com/input-output-hk/cardano-db-sync/pull/389

Note: the 6.0.0 release doesn't introduce the tx metadata feature. You'll need to re-sync from scratch the cardano-db-sync with latest master.