### PR TITLE
services/signedTransaction: convert to hex before posting

### DIFF
--- a/src/services/signedTransaction.ts
+++ b/src/services/signedTransaction.ts
@@ -15,7 +15,7 @@ export const handleSignedTx = async (req: Request, res: Response):Promise<void>=
   try {
     const endpointResponse = await axios({ method:"post"
       , url: submissionEndpoint
-      , data: buffer
+      , data: buffer.toString("hex")
       , headers: contentTypeHeaders}); 
     if(endpointResponse.status === 202){
       if(endpointResponse.data.Left){


### PR DESCRIPTION
The `cardano-rest 3.1.0` is supposed to be accepting base64 as well per documentation, but it is not working as submitted in https://github.com/input-output-hk/cardano-rest/issues/109#issuecomment-744021831.

We need to convert it to hex for now.