### PR TITLE
Revert "services/signedTransaction: convert to hex before posting"

### DIFF
--- a/src/services/signedTransaction.ts
+++ b/src/services/signedTransaction.ts
@@ -15,7 +15,7 @@ export const handleSignedTx = async (req: Request, res: Response):Promise<void>=
   try {
     const endpointResponse = await axios({ method:"post"
       , url: submissionEndpoint
-      , data: buffer.toString("hex")
+      , data: buffer
       , headers: contentTypeHeaders}); 
     if(endpointResponse.status === 202){
       if(endpointResponse.data.Left){


### PR DESCRIPTION
This reverts commit 73e7ed3cdb662dffba393dc22fecad71b1e6d834.

This now works with the latest release ` cardano-rest 3.1.1`.