### PR TITLE
add pool ids to rewards history endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,7 +154,7 @@ We recommend querying using payment key hashes (`addr_vkh`) when possible (other
     [addresses: string]: Array<{
       epoch: number,
       reward: string,
-      hashPool: string,
+      poolHash: string,
     }>
   }
   ```

--- a/README.md
+++ b/README.md
@@ -154,6 +154,7 @@ We recommend querying using payment key hashes (`addr_vkh`) when possible (other
     [addresses: string]: Array<{
       epoch: number,
       reward: string,
+      hashPool: string,
     }>
   }
   ```

--- a/src/services/rewardHistory.ts
+++ b/src/services/rewardHistory.ts
@@ -10,6 +10,7 @@ const rewardHistoryQuery = `
   select
       reward.amount
     , reward.epoch_no
+    , reward.pool_id
     , sa.hash_raw as "stakeCred"
   from reward 
   join stake_address sa on reward.addr_id = sa.id 
@@ -31,7 +32,8 @@ const askRewardHistory = async (pool: Pool, addresses: string[]): Promise<Dictio
       .filter( (r:any) => r.stakeCred.toString("hex") === addr)
       .map( (r:any) => ({
         epoch: Number.parseInt(r.epoch_no, 10),
-        reward: r.amount
+        reward: r.amount,
+        poolId: r.pool_id
       }));
 
     ret[addr] = rewardPairs;

--- a/src/services/rewardHistory.ts
+++ b/src/services/rewardHistory.ts
@@ -22,6 +22,7 @@ const rewardHistoryQuery = `
 interface RewardForEpoch {
   epoch: number;
   reward: string;
+  poolHash: string;
 }
 
 const askRewardHistory = async (pool: Pool, addresses: string[]): Promise<Dictionary<RewardForEpoch[]>> => {

--- a/src/services/rewardHistory.ts
+++ b/src/services/rewardHistory.ts
@@ -11,9 +11,11 @@ const rewardHistoryQuery = `
       reward.amount
     , reward.epoch_no
     , reward.pool_id
+    , ph.hash_raw as "poolHash"
     , sa.hash_raw as "stakeCred"
   from reward 
-  join stake_address sa on reward.addr_id = sa.id 
+  join stake_address sa on reward.addr_id = sa.id
+  join pool_hash ph on ph.id = reward.pool_id  
   where sa.hash_raw = any(($1)::bytea array) 
 `;
 
@@ -33,7 +35,7 @@ const askRewardHistory = async (pool: Pool, addresses: string[]): Promise<Dictio
       .map( (r:any) => ({
         epoch: Number.parseInt(r.epoch_no, 10),
         reward: r.amount,
-        poolId: r.pool_id
+        poolHash: r.poolHash.toString("hex")
       }));
 
     ret[addr] = rewardPairs;


### PR DESCRIPTION
add pool ids to rewards history endpoint

e.g., new response

```
{
  "e1c11ef08c44f3610b7e56d46e086b90186c12e9a68f0521b7c4c72e4b": [
    {
      "epoch": 213,
      "reward": "21200",
      "poolHash": "df1750df9b2df285fcfb50f4740657a18ee3af42727d410c37b86207"
    },
    {
      "epoch": 214,
      "reward": "19533",
      "poolHash": "0f292fcaa02b8b2f9b3c8f9fd8e0bb21abedb692a6d5058df3ef2735"
    },
    {
      "epoch": 215,
      "reward": "20948",
      "poolHash": "0f292fcaa02b8b2f9b3c8f9fd8e0bb21abedb692a6d5058df3ef2735"
    },
```