### PR TITLE
Fix REFERENCE_BEST_BLOCK_MISMATCH error

### DIFF
--- a/src/services/transactionHistory.ts
+++ b/src/services/transactionHistory.ts
@@ -380,6 +380,8 @@ export const askBlockNumByHash = async (pool: Pool, hash : string) : Promise<Uti
 
     try {
         const res = await pool.query(askBlockNumByHashQuery, [hash]);
+        if(res.rows.length === 0)
+          return {kind:"error", errMsg: errMsgs.noValue};
         return {
             kind:"ok",
             value: res.rows[0].blockNumber


### PR DESCRIPTION
When removing graphql (#134), this bug was introduced

Querying a block that doesn't exist as the "untilBlock" for a tx history query should throw a `REFERENCE_BEST_BLOCK_MISMATCH` error, but instead it got `TypeError: Cannot read property 'blockNumber' of undefined`