### PR TITLE
Do not include unredeemable MIRs in /account/state response field `remainingAmount`

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,9 +129,10 @@ We recommend querying using payment key hashes (`addr_vkh`) when possible (other
   {
     [addresses: string]: null | {|
       poolOperator: null, // not implemented yet
-      remainingAmount: string, // current remaining awards
+      remainingAmount: string, // current redeemable awards
       rewards: string, //all the rewards every added (not implemented yet)
-      withdrawals: string // all the withdrawals that have ever happened (not implemented yet)
+      withdrawals: string, // all the withdrawals that have ever happened (not implemented yet)
+      unredeemable: string, // MIR amount not yet redeemable
     |}
   }
   ```

--- a/src/services/accountState.ts
+++ b/src/services/accountState.ts
@@ -6,20 +6,32 @@ import { Request, Response } from "express";
 
 const addrReqLimit:number = config.get("server.addressRequestLimit");
 
+const currentEpochQuery = 'select max (epoch_no) as epoch from block';
+
+// parameters:
+// $1: the array of addresses being queried
+// $2: the last epoch in which MIRs issued are redeemable (i.e. MIRs after this
+//     epoch is not yet redeemable)
 const accountRewardsQuery = `
   select stake_address.hash_raw as "stakeAddress"
        , sum(coalesce("totalTreasury".amount, 0) + coalesce("totalReserve".amount, 0) - coalesce("totalWithdrawal".amount,0) + coalesce("totalReward".amount,0)) as "remainingAmount"
        , sum(coalesce("totalTreasury".amount, 0) + coalesce("totalReserve".amount, 0) + coalesce("totalReward".amount,0)) as "reward"
        , sum(coalesce("totalWithdrawal".amount, 0)) as "withdrawal"
+       , sum(coalesce("totalTreasury".unredeemable, 0) + coalesce("totalReserve".unredeemable, 0)) as "unreemdable"
 
   from stake_address
 
   left outer join (
     ${/* this comes from MIR certificates */""}
-    SELECT addr_id, sum(amount) as "amount"
+    SELECT
+      addr_id,
+      sum(CASE WHEN block.epoch_no <= $2 THEN amount ELSE 0 END) as "amount",
+      sum(CASE WHEN block.epoch_no > $2 THEN amount ELSE 0 END) as "unredeemable"
     FROM reserve
     JOIN stake_address reserve_stake_address
     ON reserve_stake_address.id = reserve.addr_id
+    JOIN tx ON tx.id = reserve.tx_id
+    JOIN block ON block.id = tx.block_id
     WHERE encode(reserve_stake_address.hash_raw, 'hex') = any(($1)::varchar array) 
     GROUP BY
       addr_id
@@ -27,10 +39,15 @@ const accountRewardsQuery = `
 
   left outer join (
     ${/* this comes from MIR certificates */""}
-    SELECT addr_id, sum(amount) as "amount"
+    SELECT
+      addr_id,
+      sum(CASE WHEN block.epoch_no <= $2 THEN amount ELSE 0 END) as "amount",
+      sum(CASE WHEN block.epoch_no > $2 THEN amount ELSE 0 END) as "unredeemable"
     FROM treasury
     join stake_address treasury_stake_address
     on treasury_stake_address.id = treasury.addr_id
+    JOIN tx ON tx.id = treasury.tx_id
+    JOIN block ON block.id = tx.block_id
     where encode(treasury_stake_address.hash_raw, 'hex') = any(($1)::varchar array) 
     GROUP BY
       addr_id
@@ -66,21 +83,35 @@ interface RewardInfo {
   rewards: string;
   withdrawals: string;
   poolOperator: null;
+  unredeemable: string;
 }
 
 interface Dictionary<T> {
     [key: string]: T;
 }
 
+// After this number of epochs the MIR becomes redeemable
+const NUMBER_OF_EPOCHS_TO_REDEEM_MIR = 1;
+
 const askAccountRewards = async (pool: Pool, addresses: string[]): Promise<Dictionary<RewardInfo|null>> => {
+  const currentEpochQueryResult = await pool.query(currentEpochQuery);
+  if (currentEpochQueryResult.rows.length !== 1) {
+    throw new Error('failed to get current epoch');
+  }
+  const currentEpoch = currentEpochQueryResult.rows[0].epoch;
+
   const ret : Dictionary<RewardInfo|null> = {};
-  const rewards = await pool.query(accountRewardsQuery, [addresses]);
+  const rewards = await pool.query(
+    accountRewardsQuery,
+    [addresses, currentEpoch - NUMBER_OF_EPOCHS_TO_REDEEM_MIR],
+  );
   for(const row of rewards.rows) {
     ret[row.stakeAddress.toString("hex")] = {
         remainingAmount: row.remainingAmount
       , rewards: row.reward
       , withdrawals: row.withdrawal
       , poolOperator: null //not implemented
+      , unredeemable: row.unredeemable
     };
   }
   for( const addr of addresses)


### PR DESCRIPTION
Originally, the MIRs, regardless of their epochs, are summed into `remainingAmount`. This is problematic because when Yoroi creates a reward-withdrawal tx, it uses this amount. But because the MIRs may not be yet redeemable in the current epoch, the tx would fail. Now only redeemable MIRs are summed into `remainAmount` and a new field `unredeemable` is added to return the yet redeemable MIRs.