### PR TITLE
changes to query rewards only from reward table and use new epoch cols

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,2 @@
 engine-strict=true
+unsafe-perm=true

--- a/src/services/accountState.ts
+++ b/src/services/accountState.ts
@@ -17,10 +17,11 @@ const accountRewardsQuery = `
   left outer join (
     ${/* this comes from MIR certificates */""}
     SELECT addr_id, sum(amount) as "amount"
-    FROM reserve
+    FROM reward
     JOIN stake_address reserve_stake_address
-    ON reserve_stake_address.id = reserve.addr_id
+    ON reserve_stake_address.id = reward.addr_id
     WHERE encode(reserve_stake_address.hash_raw, 'hex') = any(($1)::varchar array) 
+      AND reward.type = 'reserves'
     GROUP BY
       addr_id
   ) as "totalReserve" on stake_address.id = "totalReserve".addr_id
@@ -28,10 +29,11 @@ const accountRewardsQuery = `
   left outer join (
     ${/* this comes from MIR certificates */""}
     SELECT addr_id, sum(amount) as "amount"
-    FROM treasury
+    FROM reward
     join stake_address treasury_stake_address
-    on treasury_stake_address.id = treasury.addr_id
+    on treasury_stake_address.id = reward.addr_id
     where encode(treasury_stake_address.hash_raw, 'hex') = any(($1)::varchar array) 
+      and reward.type = 'treasury'
     GROUP BY
       addr_id
   ) as "totalTreasury" on stake_address.id = "totalTreasury".addr_id
@@ -51,7 +53,7 @@ const accountRewardsQuery = `
     FROM reward
     join stake_address reward_stake_address
     on reward_stake_address.id = reward.addr_id
-    where encode(reward_stake_address.hash_raw, 'hex') = any(($1)::varchar array) 
+    where encode(reward_stake_address.hash_raw, 'hex') = any(($1)::varchar array)
     GROUP BY
 	    addr_id
   ) as "totalReward" on stake_address.id = "totalReward".addr_id

--- a/src/services/poolInfo.ts
+++ b/src/services/poolInfo.ts
@@ -26,12 +26,12 @@ export interface PoolHistory {
 }
 
 export const latestMetadataQuery = `
-  select encode(pool_meta_data.hash, 'hex') as "metadata_hash"
+  select encode(pool_metadata_ref.hash, 'hex') as "metadata_hash"
      from pool_hash
      join pool_update 
           on pool_hash.id = pool_update.hash_id 
-     join pool_meta_data 
-          on pool_update.meta_id = pool_meta_data.id
+     join pool_metadata_ref
+          on pool_update.meta_id = pool_metadata_ref.id
      where encode(pool_hash.hash_raw, 'hex') = $1
     order by pool_update.id desc limit 1;
 `;

--- a/src/services/rewardHistory.ts
+++ b/src/services/rewardHistory.ts
@@ -9,7 +9,8 @@ const addrReqLimit:number = config.get("server.addressRequestLimit");
 const rewardHistoryQuery = `
   select
       reward.amount
-    , reward.epoch_no
+    , reward.earned_epoch
+    , reward.spendable_epoch
     , reward.pool_id
     , ph.hash_raw as "poolHash"
     , sa.hash_raw as "stakeCred"
@@ -17,11 +18,12 @@ const rewardHistoryQuery = `
   join stake_address sa on reward.addr_id = sa.id
   join pool_hash ph on ph.id = reward.pool_id  
   where sa.hash_raw = any(($1)::bytea array)
-  order by reward.epoch_no
+  order by reward.earned_epoch
 `;
 
 interface RewardForEpoch {
   epoch: number;
+  spendableEpoch: number;
   reward: string;
   poolHash: string;
 }
@@ -35,7 +37,8 @@ const askRewardHistory = async (pool: Pool, addresses: string[]): Promise<Dictio
     const rewardPairs: RewardForEpoch[] = history.rows
       .filter( (r:any) => r.stakeCred.toString("hex") === addr)
       .map( (r:any) => ({
-        epoch: Number.parseInt(r.epoch_no, 10),
+        epoch: Number.parseInt(r.earned_epoch, 10),
+        spendableEpoch: Number.parseInt(r.spendable_epoch, 10),
         reward: r.amount,
         poolHash: r.poolHash.toString("hex")
       }));

--- a/tests/getPoolInfo.test.ts
+++ b/tests/getPoolInfo.test.ts
@@ -43,11 +43,17 @@ describe("/pool/info", function() {
     expect(result.data[poolId]).to.have.property("history");
 
     const { history } = result.data[poolId];
-    // since the parameters can be changed in the time after we right this test
-    // we just make sure that the suffix of the pool history matches what existed at the time this test was written
-    const suffix = history.slice(history.length - stakhanoviteHistorySuffix.length, history.length);
 
-    expect(suffix).to.deep.equal(stakhanoviteHistorySuffix);
+    for (const item of stakhanoviteHistorySuffix) {
+      const itemFromDb = history
+        .find((x: any) => x.epoch === item.epoch
+          && x.slot === item.slot
+          && x.tx_ordinal === item.tx_ordinal
+          && x.cert_ordinal === item.cert_ordinal);
+
+      expect(itemFromDb).to.be.ok;
+      expect(itemFromDb).to.deep.equal(item);
+    }
   });
 });
 
@@ -66,7 +72,7 @@ const stakhanoviteHistorySuffix = [{
       "cost": "340000000",
       "margin": 0.019,
       "rewardAccount": "e10af10f4a5d365af01f0ca7651713a8a073263b61bbd1f69623097bd7",
-      "poolOwners": ["e9aba14ed15240e855f5b62d28f0e5f913cf9c289d3cbc5d6016c1b1", "7dfe98a743499f7a67ab2f9771e683d2e9fa1a53b4632aa7e1df339f", "0a03ee791abf663e98b81661dadd72420f29bb6960ca0a676e75dd70"],
+      "poolOwners": ["e1e9aba14ed15240e855f5b62d28f0e5f913cf9c289d3cbc5d6016c1b1", "e17dfe98a743499f7a67ab2f9771e683d2e9fa1a53b4632aa7e1df339f", "e10a03ee791abf663e98b81661dadd72420f29bb6960ca0a676e75dd70"],
       "relays": [{
         "ipv4": null,
         "ipv6": null,
@@ -95,7 +101,7 @@ const stakhanoviteHistorySuffix = [{
       "cost": "340000000",
       "margin": 0.019,
       "rewardAccount": "e10af10f4a5d365af01f0ca7651713a8a073263b61bbd1f69623097bd7",
-      "poolOwners": ["e9aba14ed15240e855f5b62d28f0e5f913cf9c289d3cbc5d6016c1b1", "3e04ddd9d0a3b383ff5ee2e813060b337ad2228bb51bab6dc6d843fa"],
+      "poolOwners": ["e1e9aba14ed15240e855f5b62d28f0e5f913cf9c289d3cbc5d6016c1b1", "e13e04ddd9d0a3b383ff5ee2e813060b337ad2228bb51bab6dc6d843fa"],
       "relays": [{
         "ipv4": null,
         "ipv6": null,
@@ -124,7 +130,7 @@ const stakhanoviteHistorySuffix = [{
       "cost": "340000000",
       "margin": 0.019,
       "rewardAccount": "e1854139fc8987990fd89699beb1b59b09c047ace356870dcaadc93b22",
-      "poolOwners": ["3e04ddd9d0a3b383ff5ee2e813060b337ad2228bb51bab6dc6d843fa"],
+      "poolOwners": ["e13e04ddd9d0a3b383ff5ee2e813060b337ad2228bb51bab6dc6d843fa"],
       "relays": [{
         "ipv4": null,
         "ipv6": null,
@@ -153,7 +159,7 @@ const stakhanoviteHistorySuffix = [{
       "cost": "340000000",
       "margin": 0.019,
       "rewardAccount": "e1854139fc8987990fd89699beb1b59b09c047ace356870dcaadc93b22",
-      "poolOwners": ["3e04ddd9d0a3b383ff5ee2e813060b337ad2228bb51bab6dc6d843fa"],
+      "poolOwners": ["e13e04ddd9d0a3b383ff5ee2e813060b337ad2228bb51bab6dc6d843fa"],
       "relays": [{
         "ipv4": null,
         "ipv6": null,
@@ -182,7 +188,7 @@ const stakhanoviteHistorySuffix = [{
       "cost": "340000000",
       "margin": 0.019,
       "rewardAccount": "e1854139fc8987990fd89699beb1b59b09c047ace356870dcaadc93b22",
-      "poolOwners": ["3e04ddd9d0a3b383ff5ee2e813060b337ad2228bb51bab6dc6d843fa"],
+      "poolOwners": ["e13e04ddd9d0a3b383ff5ee2e813060b337ad2228bb51bab6dc6d843fa"],
       "relays": [{
         "ipv4": null,
         "ipv6": null,
@@ -211,7 +217,7 @@ const stakhanoviteHistorySuffix = [{
       "cost": "340000000",
       "margin": 0.01935,
       "rewardAccount": "e1854139fc8987990fd89699beb1b59b09c047ace356870dcaadc93b22",
-      "poolOwners": ["3e04ddd9d0a3b383ff5ee2e813060b337ad2228bb51bab6dc6d843fa"],
+      "poolOwners": ["e13e04ddd9d0a3b383ff5ee2e813060b337ad2228bb51bab6dc6d843fa"],
       "relays": [{
         "ipv4": null,
         "ipv6": null,
@@ -240,7 +246,7 @@ const stakhanoviteHistorySuffix = [{
       "cost": "340000000",
       "margin": 0.01935,
       "rewardAccount": "e1aaba5c420ee082c1ed96e838dc21b1b3ba700bfc74425f816c0ceaca",
-      "poolOwners": ["1f6aa9c55c35acd337ddd469b7e98dbea4f4a4c1d141ae2baf87a75c"],
+      "poolOwners": ["e11f6aa9c55c35acd337ddd469b7e98dbea4f4a4c1d141ae2baf87a75c"],
       "relays": [{
         "ipv4": null,
         "ipv6": null,


### PR DESCRIPTION
## Abstract
These changes aim to return treasury and reserves information directly from the `reward` table, as well as return the data from the new epoch columns in the reward history endpoint.

## Background
See the [task on Asana](https://app.asana.com/0/1200842454080452/1200648261290964) for more background.

## Motivation
There are some schema changes at `cardano-db-sync` referent to the rewards, namely, the `treasury` and `reserve` tables are no longer necessary, as their data is now being stored directly on the `reward` table. We can check whether the reward is treasury or reserve by the `type` column in the `reward` table.

## Implementation
The implementation consists of the following parts:

### Change reward history query
Change the `epoch_no` column to `earned_epoch` and add the new `spendable_epoch`. Also add `spendableEpoch` to the `interface` wee return and map it appropriately. The `epoch` property on the `interface` is kept with the same name to not break any clients.

### Change the account state query
~~Instead of joining `reserve` and `treasury`, we join `reward` and filter the type appropriately.~~
Remove the `totalReserve` and `totalTreasury` sub query joins which gets the rewards from the `reserve` and `treasury` tables, as all this data is coming from the `reward` table now. In the `totalReward` sub query, we split the amount into `spendable_amount` and `non_spendable_amount`, based on a comparison between the `max(epoch_no)` from `block` and the `spendable_epoch` column from `reward`; we then make the following changes to the outer-most `select`:
- calculate `remainingAmount` by subtracting only the spendable amount from the withdraw amount;
- add a new column named `remainingNonSpendableAmount`, which is just a sum of the `non_spendable_amount` calculated as mentioned above in this section;
- calculate the `reward` column by summing all the spendable and non-spendable amounts.

We also add the new `remainingNonSpendableAmount` property to `RewardInfo` and map it appropriately from the DB results.

**OBS: I am not 100% happy with `remainingNonSpendableAmount` as the name of this property as it seems too big, but I couldn't think of anything better which was still descriptive, so please let me know in case you have a better name for this.**

### Change the certificates view
This view was actually broken, so I am not sure if it is actually used anywhere, but in any case, it does use the `treasury` and `reserve` tables.
#### 1. Use `reserve` instead of `treasury` and `reserve`
Changed it to join `reward` and filter the type instead. In this case, the query was using info which was only available at the `treasury` and `reserve` tables, so I did changes to get these from somewhere else:
- txId: before it was `reserve.tx_id`; changed to be the `registered_tx_id` from `stake_address`;
- certIndex: before it was `max(reserve.cert_index)`; changed to join the `stake_registration` through the `stake_address` and do a max on the `cert_index` from `stake_registration` instead.

#### 2. Fix the "PoolRegistration" query
This query had 2 problems which broke the `view`:
- it was using a `pool_meta_data` table, which does not exists, so I changed it to use `pool_metadata_ref` instead. See the `cardano-db-sync` [Schema Documentation](https://github.com/input-output-hk/cardano-db-sync/blob/master/doc/schema.md)
- It wasn't applying the group by to the selected columns , even though an aggregation operation was being made, which throws a SQL error when we try selecting the view.

Moreover, I believe I found a bug in the `poolParamsOwners` of this query, as it was using the hash from the pool in this column, and not the hash from address of the the stake pool owner, so I changed it accordingly.

#### 3. Fix the `/pool/info` history test
Specifically, the test **should return the right start of the history for STKH1** had to be fixed for the following reasons:
- it was trying to compare the suffix of the history to some fixed data which was get at the time the code was written. This shouldn't work if the DB gets updated as the suffix will be different. Also, I don't like the idea of trusting the exact order of the array. Because of these reasons, I changed it to get each item from the expected  `stakhanoviteHistorySuffix` individually, and then `asserting` they have a match on the history we retrieved from the DB;
- as I changed the logic for getting the `poolOwners`, I also changed the expected `poolOwners` from the test data