### PR TITLE
Add endpoint for getting the metadata from a mint transaction

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -25,6 +25,7 @@ import { handlePoolInfo } from "./services/poolInfo";
 import { handleGetAccountState } from "./services/accountState";
 import { handleGetRegHistory } from "./services/regHistory";
 import { handleGetRewardHistory } from "./services/rewardHistory";
+import { handleGetMultiAssetTxMintMetadata } from "./services/multiAssetTxMint";
 
 import { HealthChecker } from "./HealthChecker";
 
@@ -294,6 +295,11 @@ const routes : Route[] = [
     path: "/pool/cardanoWallet",
     method: "get",
     handler: handleGetCardanoWalletPools(pool)
+  },
+  {
+    path: "/multiAsset/metadata",
+    method: "post",
+    handler: handleGetMultiAssetTxMintMetadata(pool)
   }
 , { path: "/v2/importerhealthcheck"
   , method: "get"

--- a/src/services/multiAssetTxMint.ts
+++ b/src/services/multiAssetTxMint.ts
@@ -1,0 +1,67 @@
+import { Pool } from "pg";
+import { Request, Response } from "express";
+
+interface Asset {
+  name: string
+  policy: string
+}
+
+interface MultiAssetTxMintMetadata {
+  key: string
+  metadata: any
+}
+
+const getMultiAssetTxMintMetadata = async (pool: Pool, assets: Asset[]) => {
+  const query = createGetMultiAssetTxMintMetadataQuery(assets);
+
+  const params = assets
+    .map(a => [a.name, a.policy])
+    .reduce((prev, curr) => prev.concat(curr), []);
+
+  const ret: {[key: string]: MultiAssetTxMintMetadata[]} = {};
+
+  const results = await pool.query(query, params);
+  for (const row of results.rows) {
+    const policyAndName = `${row.policy}.${row.asset}`;
+    if (!ret[policyAndName]) {
+      ret[policyAndName] = new Array<MultiAssetTxMintMetadata>();
+    }
+
+    ret[policyAndName].push({
+      key: row.key,
+      metadata: row.json
+    });
+  }
+
+  return ret;
+};
+
+export const handleGetMultiAssetTxMintMetadata = (pool: Pool) => async (req: Request, res:Response): Promise<void> => {
+  if (!req.body || !req.body.assets) throw new Error("missing assets on request body");
+  if (!Array.isArray(req.body.assets)) throw new Error("assets should be an array");
+  if (req.body.assets.length === 0) throw new Error("assets should not be empty");
+  if (req.body.assets.find((a: any) => !a.name || !a.policy)) throw new Error("all assets on body should have a name and a policy");
+
+  const assets: Asset[] = req.body.assets;
+
+  const metadata = await getMultiAssetTxMintMetadata(pool, assets);
+  res.send(metadata);
+};
+
+function createGetMultiAssetTxMintMetadataQuery(assets: Asset[]) {
+  const whereConditions = assets
+    .map((a, idx) => `( mint.name = ($${idx * 2 + 1})::bytea
+      and encode(mint.policy, 'hex') = ($${idx * 2 + 2})::varchar )`)
+    .join(" or ");
+
+  const query = `
+  select encode(mint.policy, 'hex') as policy,
+    mint.name as asset,
+    meta.key,
+    meta.json
+  from ma_tx_mint mint
+    join tx on mint.tx_id = tx.id
+    join tx_metadata meta on tx.id = meta.tx_id
+  where ${whereConditions}`;
+  return query;
+}


### PR DESCRIPTION
## Abstract
This PR has the objective of adding a new endpoint to get metadata from the minting transactions for specific tokens, given their names and policy ids

## Motivation
We need this endpoint mainly to be able to differentiate between "normal" native tokens and native tokens which are NFTs. By getting the metadata from the transaction which minted a token, we can verify if it is a NFT by checking if the `key` returned on the response is `721`.

## Background
See the [task on Asana](https://app.asana.com/0/1200842454080452/1200880500671157).
This task is for adding a function for counting token and NFT types on the Yoroi extension. Even though we have token data on the UTXOs which we can access on the extension, the data from the UTXOs is insufficient for determining if these tokens are NFTs or not.

## Implementation
The implementation is quite simple and can be divided in the following main pieces:

### The endpoint
We add the `/multiAsset/metadata` endpoint, in which we can pass an array of assets with their names and policy IDs to get back an object with the keys and metadata separated by the policy and asset name provided.

#### Sample request
```
{
    "assets": [
    {
        "name": "MyNFT",
        "policy": "a68a2e6dfb5f5e35da6fc30613bff677158ec224efa89af8973baffd"
    },
    {
        "name": "MyOtherNFT",
        "policy": "127660cee3914688f94fa61cafaecd7f5f2483e81e03060c8d79a570"
    }]
}
```

#### Sample response
```
{
  "a68a2e6dfb5f5e35da6fc30613bff677158ec224efa89af8973baffd.MyNFT": [
    {
      "key": "721",
      "metadata": {
        "a68a2e6dfb5f5e35da6fc30613bff677158ec224efa89af8973baffd": {
          "MyNFT": {
            "id": "1",
            "name": "My sample NFT"
          }
        }
      }
    },
    {
      "key": "721",
      "metadata": {
        "a68a2e6dfb5f5e35da6fc30613bff677158ec224efa89af8973baffd": {
          "MyNFT": {
            "id": "2",
            "name": "My other NFT with the same policy"
          }
        }
      }
    }
  ],
  "127660cee3914688f94fa61cafaecd7f5f2483e81e03060c8d79a570.SomeCrazyNFT": [
    {
      "key": "721",
      "metadata": {
        "127660cee3914688f94fa61cafaecd7f5f2483e81e03060c8d79a570": {
          "MyOtherNFT {
            "id": "1",
            "name": "Another NFT"
          }
        }
      }
    }
  ]
}
```

### The query
The query joins `ma_tx_mint`, `tx` and the `tx_metadata` and then filters the `name` and the `policy` from `ma_tx_mint`. We just want to return entries which have the exact match from the asset name and policy passed on the parameters, so **we cannot simply do something like `mint.name in (...) and mint.policy in (...)`**. Therefore, we create a specific `mint.name = ... and mint.policy = ...` for each of the assets and apply a `or` condition between them.