### PR TITLE
Include tx valid_contract and script_size fields on tx history response

### DIFF
--- a/src/Transactions/certificates.ts
+++ b/src/Transactions/certificates.ts
@@ -98,8 +98,8 @@ select 'PoolRegistration' as "jsType"
      , pool.fixed_cost as "poolParamsCost"
      , pool.margin as "poolParamsMargin"
      , encode(addr.hash_raw,'hex') as "poolParamsRewardAccount"
-     , ( select json_agg(encode(hash,'hex'))
-         from pool_owner
+     , ( select json_agg(encode(stake_address.hash_raw,'hex'))
+         from pool_owner inner join stake_address on pool_owner.addr_id = stake_address.id
          where
           pool_owner.pool_hash_id = pool_hash.id
           and
@@ -123,8 +123,21 @@ join pool_hash
   on pool.hash_id = pool_hash.id
 join stake_address as addr
   on addr.hash_raw = pool.reward_addr
-left join pool_meta_data as pool_meta
+left join pool_metadata_ref as pool_meta
   on pool_meta.id = pool.meta_id
+group by pool.registered_tx_id
+  , pool.cert_index
+  , pool_hash.hash_raw
+  , pool.vrf_key_hash
+  , pool.pledge
+  , pool.fixed_cost
+  , pool.margin
+  , addr.hash_raw
+  , pool.hash_id
+  , pool_hash.id
+  , pool.id
+  , pool_meta.url
+  , pool_meta.hash
 
 UNION ALL
   

--- a/src/Transactions/types.ts
+++ b/src/Transactions/types.ts
@@ -6,6 +6,8 @@ export enum BlockEra { Byron = "byron"
 export interface TransactionFrag {
     hash: string;
     fee: string;
+    validContract: boolean;
+    scriptSize: number;
     ttl: string;
     blockEra: BlockEra;
     metadata: null | string;

--- a/src/index.ts
+++ b/src/index.ts
@@ -157,6 +157,8 @@ const txHistory = async (req: Request, res: Response) => {
         hash: tx.hash,
         fee: tx.fee,
         metadata: tx.metadata,
+        validContract: tx.validContract,
+        scriptSize: tx.scriptSize,
         //ttl: tx.ttl,
         type: tx.blockEra,
         withdrawals: tx.withdrawals,

--- a/src/services/transactionHistory.ts
+++ b/src/services/transactionHistory.ts
@@ -110,6 +110,8 @@ const askTransactionSqlQuery = `
     )
   select tx.hash
        , tx.fee
+       , tx.valid_contract
+       , tx.script_size
        , (select jsonb_object_agg(key, bytes)
         from tx_metadata
         where tx_metadata.tx_id = tx.id) as metadata
@@ -167,8 +169,8 @@ const askTransactionSqlQuery = `
   JOIN block
     on block.id = tx.block_id
 
-  LEFT JOIN pool_meta_data 
-    on tx.id = pool_meta_data.registered_tx_id 
+  LEFT JOIN pool_metadata_ref
+    on tx.id = pool_metadata_ref.registered_tx_id 
 
   where 
         ${/* is within untilBlock (inclusive) */""}
@@ -282,6 +284,8 @@ export const askTransactionHistory = async (
       , slotNo: row.blockSlotInEpoch };
     return { hash: row.hash.toString("hex")
       , block: blockFrag
+      , validContract: row.valid_contract
+      , scriptSize: row.script_size
       , fee: row.fee.toString()
       , metadata: buildMetadataObj(row.metadata)
       , includedAt: row.includedAt


### PR DESCRIPTION
# Abstract
This PR includes the new columns `valid_contract` and `script_size` from `tx` table in the transactions history response. It also fixes some bugs which prevented the correct functioning of the `v2/txs/history` endpoint.

# Background
See the [task on Asana](https://app.asana.com/0/1200528935481340/1200936111290863/f)

# Implementation
### Bug fixes on the `combined_certificates` view

This view is used on the query from the `v2/txs/history` endpoint and there were three bugs here, two which prevents the view from being created at all and another one which causes a runtime error (when someone actually runs a query against the view):
- in db-sync 11, the table `pool_meta_data` was renamed to `pool_metadata_ref`, **so we change the reference with the old name in this view**;
- the 4th query in the view contains a aggregate function, but it doesn't include a `group by` clause with the fields being selected. This causes the error creating the view, **therefore, we add the appropriate `group by` clause**;
- also in the 4th query, the sub-query which generates the `poolParamsOwners` column was selecting `json_agg(encode(hash,'hex'))`. This is a problem because this `hash` column passed to `encode` and `json_agg` is coming from the outer query, which not only causes the error `[21000] ERROR: more than one row returned by a subquery used as an expression`, but also doesn't really selects the hash from the pool owner. **To fix that, we join `pool_owner` with `stake_address` in this sub-query and use `stake_address.hash_raw` instead of `hash`**.

This fix is also included on the PRs #260 and #252 , so it might not be shown on the `diff` depending on each one gets merged first.

### Include the new columns in the query and in the response
This is pretty simple, we just include the new columns in the `askTransactionSqlQuery` query from `transactionHistory.ts`, add the new fields to the `TransactionFrag` interface and map them appropriately at the `askTransactionHistory` and `txHistory` functions.