### PR TITLE
Return collateral input UTxOs at transaction history

### DIFF
--- a/src/Transactions/certificates.ts
+++ b/src/Transactions/certificates.ts
@@ -98,8 +98,8 @@ select 'PoolRegistration' as "jsType"
      , pool.fixed_cost as "poolParamsCost"
      , pool.margin as "poolParamsMargin"
      , encode(addr.hash_raw,'hex') as "poolParamsRewardAccount"
-     , ( select json_agg(encode(hash,'hex'))
-         from pool_owner
+     , ( select json_agg(encode(stake_address.hash_raw,'hex'))
+         from pool_owner inner join stake_address on pool_owner.addr_id = stake_address.id
          where
           pool_owner.pool_hash_id = pool_hash.id
           and
@@ -123,8 +123,21 @@ join pool_hash
   on pool.hash_id = pool_hash.id
 join stake_address as addr
   on addr.hash_raw = pool.reward_addr
-left join pool_meta_data as pool_meta
+left join pool_metadata_ref as pool_meta
   on pool_meta.id = pool.meta_id
+group by pool.registered_tx_id
+  , pool.cert_index
+  , pool_hash.hash_raw
+  , pool.vrf_key_hash
+  , pool.pledge
+  , pool.fixed_cost
+  , pool.margin
+  , addr.hash_raw
+  , pool.hash_id
+  , pool_hash.id
+  , pool.id
+  , pool_meta.url
+  , pool_meta.hash
 
 UNION ALL
   

--- a/src/Transactions/types.ts
+++ b/src/Transactions/types.ts
@@ -12,6 +12,7 @@ export interface TransactionFrag {
     block: BlockFrag;
     includedAt: Date;
     inputs: TransInputFrag[];
+    collateralInputs: TransInputFrag[];
     outputs: TransOutputFrag[]; // technically a TransactionOutput fragment
     txIndex: number;
     withdrawals: TransOutputFrag[];

--- a/src/index.ts
+++ b/src/index.ts
@@ -170,6 +170,7 @@ const txHistory = async (req: Request, res: Response) => {
         epoch: tx.block.epochNo,
         slot: tx.block.slotNo,
         inputs: tx.inputs,
+        collateralInputs: tx.collateralInputs,
         outputs: tx.outputs
       }));
 

--- a/src/services/transactionHistory.ts
+++ b/src/services/transactionHistory.ts
@@ -292,7 +292,7 @@ export const askTransactionHistory = async (
     , addressTypes.stakingKeys
   ]);
   const txs = ret.rows.map( (row: any):TransactionFrag => {
-    let inputs = row.inAddrValPairs 
+    const inputs = row.inAddrValPairs 
       ? row.inAddrValPairs.map((obj: any): TransInputFrag => ({
             address: obj.f1,
             amount: obj.f2.toString(),
@@ -302,7 +302,7 @@ export const askTransactionHistory = async (
             assets: extractAssets(obj.f5)
       }))
       : []; 
-    const collaterals = row.collateralInAddrValPairs 
+    const collateralInputs = row.collateralInAddrValPairs 
       ? row.collateralInAddrValPairs.map((obj: any): TransInputFrag => ({
             address: obj.f1,
             amount: obj.f2.toString(),
@@ -311,8 +311,7 @@ export const askTransactionHistory = async (
             txHash: obj.f3,
             assets: extractAssets(obj.f5)
       }))
-      : []; 
-    inputs = inputs.concat(collaterals);
+      : [];
     const outputs = row.outAddrValPairs 
       ? row.outAddrValPairs.map((obj: any): TransOutputFrag => ({
             address: obj.f1,
@@ -338,6 +337,7 @@ export const askTransactionHistory = async (
       , metadata: buildMetadataObj(row.metadata)
       , includedAt: row.includedAt
       , inputs: inputs
+      , collateralInputs: collateralInputs
       , outputs: outputs
       , ttl: MAX_INT // https://github.com/input-output-hk/cardano-db-sync/issues/212
       , blockEra: row.blockEra === "byron" ? BlockEra.Byron : BlockEra.Shelley

--- a/src/services/transactionHistory.ts
+++ b/src/services/transactionHistory.ts
@@ -36,7 +36,7 @@ const askTransactionSqlQuery = `
     hashes as (
       select distinct hash
       from (
-            ${/* 1) Get all inputs for the transaction */""}
+            ${/* 1.1) Get all inputs for the transaction */""}
 
             select tx.hash as hash
             FROM tx
@@ -58,6 +58,31 @@ const askTransactionSqlQuery = `
 
             WHERE source_tx_out.address = ANY(($1)::varchar array)
                OR source_tx_out.payment_cred = ANY(($6)::bytea array)
+
+          UNION
+
+          ${/* 1.2) Get all collateral inputs for the transaction */""}
+
+          select tx.hash as hash
+            FROM tx
+
+            JOIN collateral_tx_in 
+              ON collateral_tx_in.tx_in_id = tx.id
+
+            ${/**
+              note: input table doesn't contain addresses directly
+              so to check for all inputs that use address X
+              we have to check the address for all outputs that occur in the input table
+            **/""}
+            JOIN tx_out source_tx_out 
+              ON collateral_tx_in.tx_out_id = source_tx_out.tx_id 
+            AND collateral_tx_in.tx_out_index::smallint = source_tx_out.index::smallint
+
+            JOIN tx source_tx 
+              ON source_tx_out.tx_id = source_tx.id
+
+            WHERE source_tx_out.address = ANY(($1)::varchar array)
+              OR source_tx_out.payment_cred = ANY(($6)::bytea array)
 
           UNION
             ${/* 2) Get all outputs for the transaction */""}
@@ -139,6 +164,22 @@ const askTransactionSqlQuery = `
           JOIN tx source_tx 
             ON source_tx_out.tx_id = source_tx.id
           where inadd_tx.hash = tx.hash) as "inAddrValPairs"
+        , (select json_agg(( source_tx_out.address
+            , source_tx_out.value
+            , encode(source_tx.hash, 'hex')
+            , collateral_tx_in.tx_out_index
+            , (select json_agg(ROW(encode("policy", 'hex'), encode("name", 'hex'), "quantity"))
+              from ma_tx_out
+              WHERE ma_tx_out."tx_out_id" = source_tx_out.id)
+            ) order by collateral_tx_in.id asc) as collateralInAddrValPairs
+          FROM tx inadd_tx
+          JOIN collateral_tx_in
+          ON collateral_tx_in.tx_in_id = inadd_tx.id
+          JOIN tx_out source_tx_out 
+          ON collateral_tx_in.tx_out_id = source_tx_out.tx_id AND collateral_tx_in.tx_out_index::smallint = source_tx_out.index::smallint
+          JOIN tx source_tx 
+          ON source_tx_out.tx_id = source_tx.id
+          where inadd_tx.hash = tx.hash) as "collateralInAddrValPairs"
        , (select json_agg((
                     "address", 
                     "value",
@@ -167,8 +208,8 @@ const askTransactionSqlQuery = `
   JOIN block
     on block.id = tx.block_id
 
-  LEFT JOIN pool_meta_data 
-    on tx.id = pool_meta_data.registered_tx_id 
+  LEFT JOIN pool_metadata_ref 
+    on tx.id = pool_metadata_ref.registered_tx_id 
 
   where 
         ${/* is within untilBlock (inclusive) */""}
@@ -251,7 +292,7 @@ export const askTransactionHistory = async (
     , addressTypes.stakingKeys
   ]);
   const txs = ret.rows.map( (row: any):TransactionFrag => {
-    const inputs = row.inAddrValPairs 
+    let inputs = row.inAddrValPairs 
       ? row.inAddrValPairs.map((obj: any): TransInputFrag => ({
             address: obj.f1,
             amount: obj.f2.toString(),
@@ -261,6 +302,17 @@ export const askTransactionHistory = async (
             assets: extractAssets(obj.f5)
       }))
       : []; 
+    const collaterals = row.collateralInAddrValPairs 
+      ? row.collateralInAddrValPairs.map((obj: any): TransInputFrag => ({
+            address: obj.f1,
+            amount: obj.f2.toString(),
+            id: obj.f3.concat(obj.f4.toString()),
+            index: obj.f4,
+            txHash: obj.f3,
+            assets: extractAssets(obj.f5)
+      }))
+      : []; 
+    inputs = inputs.concat(collaterals);
     const outputs = row.outAddrValPairs 
       ? row.outAddrValPairs.map((obj: any): TransOutputFrag => ({
             address: obj.f1,


### PR DESCRIPTION
# Abstract
This PR contains changes for returning the UTxOs from collateral inputs at the `/v2/txs/history` endpoint.

# Background
In db-sync 11 it was added a new table named `collateral_tx_in`, which serves the same purpose as `tx_in` but for inputs referring collaterals for script exceution for the transaction.
See the [task on Asana](https://app.asana.com/0/1200528935481340/1200936111290864/f)

# Implementation

### Bug fixes on the `combined_certificates` view

This view is used on the query from the `v2/txs/history` endpoint and there were three bugs here, two which prevents the view from being created at all and another one which causes a runtime error (when someone actually runs a query against the view):
- in db-sync 11, the table `pool_meta_data` was renamed to `pool_metadata_ref`, **so we change the reference with the old name in this view**;
- the 4th query in the view contains a aggregate function, but it doesn't include a `group by` clause with the fields being selected. This causes the error creating the view, **therefore, we add the appropriate `group by` clause**;
- also in the 4th query, the sub-query which generates the `poolParamsOwners` column was selecting `json_agg(encode(hash,'hex'))`. This is a problem because this `hash` column passed to `encode` and `json_agg` is coming from the outer query, which not only causes the error `[21000] ERROR: more than one row returned by a subquery used as an expression`, but also doesn't really selects the hash from the pool owner. **To fix that, we join `pool_owner` with `stake_address` in this sub-query and use `stake_address.hash_raw` instead of `hash`**.

This fix is also included on the PRs #259 and #252 , so it might not be shown on the `diff` depending on each one gets merged first.

### Changes to the `askTransactionSqlQuery`
The changes to this query are pretty simple, we basically duplicate two sub-queries which use `tx_in` and modify it to use `collateral_tx_in` instead. The queries are:
- the first query from the `hashes` `CTE`;
- the sub-query which generates the `inAddrValPairs` column, but change the name of the duplicate to `collateralInAddrValPairs`.

We then ~concatenate the collaterals inputs with the "regular" inputs~ add a new field to `TransactionFrag` named `collateralInputs` and map the `collateralInAddrValPairs` column from the query to it so it is returned in the response.
