### PR TITLE
Add check for invalid contracts at UTxOs querying and summing

### DIFF
--- a/src/services/utxoForAddress.ts
+++ b/src/services/utxoForAddress.ts
@@ -22,6 +22,7 @@ const utxoForAddressQuery = `
   JOIN block
     on block.id = tx.block_id
   WHERE tx_in.tx_in_id IS NULL
+    and tx.valid_contract
     and (   tx_out.address = any(($1)::varchar array) 
          or tx_out.payment_cred = any(($2)::bytea array));
 `;

--- a/src/services/utxoSumForAddress.ts
+++ b/src/services/utxoSumForAddress.ts
@@ -6,7 +6,9 @@ export const askUtxoSumForAddresses = async (pool: Pool, addresses: string[]): P
     const sqlQuery = `
     SELECT "public"."utxo_view"."value" AS "value"
     FROM "public"."utxo_view"
+    LEFT JOIN "tx" ON "utxo_view"."tx_id" = "tx"."id"
     WHERE "public"."utxo_view"."address" = any(($1)::varchar array)
+    AND ("tx"."valid_contract" OR "tx"."id" IS NULL)
     GROUP BY "public"."utxo_view"."value"
     ORDER BY "public"."utxo_view"."value" ASC
   `;


### PR DESCRIPTION
# Abstract
This PR adds a check for invalid contracts at the endpoints `/txs/utxoForAddresses` and `/txs/utxoSumForAddresses`

# Background
db-sync 11 adds the new column `valid_contract` in the `tx` table, so we want to retrieve only the txs with valid contracts on the endpoints mentioned above.
See the [task on Asana](https://app.asana.com/0/1200528935481340/1200691762858110/f)

# Implementation
- Modify the `utxoForAddressQuery` query to only return rows where `valid_contract` is `true`;
- Modify the query at `askUtxoSumForAddresses` to make a `left join` with the `tx` table to give us access to the `valid_contract` column, and then only sum up the rows which have this column as `true`. We also sum up the results which could not be joined with `tx`. We do this because previously this join was not on the query and inspecting the code from the `utxo_view`, we can see it also does a `left join` with `tx`, which indicates there's the possibility of a entry at `utxo_view` which is not on `tx`.