### PR TITLE
better error info when tx submission fails

### DIFF
--- a/src/services/signedTransaction.ts
+++ b/src/services/signedTransaction.ts
@@ -29,7 +29,7 @@ export const handleSignedTx = async (req: Request, res: Response):Promise<void>=
       throw Error(`I did not understand the response from the submission endpoint: ${endpointResponse.data}`);
     }
   } catch(error: any) {
-    const msg = `Error trying to send transaction: ${error} - ${error.response.data}`;
+    const msg = `Error trying to send transaction: ${error} - ${JSON.stringify(error.response.data)}`;
     throw Error(msg);
   }
 


### PR DESCRIPTION
Currently, the error response when tx submission fails is like this:
```
{"error":{"response":"Error trying to send transaction: Error: Request failed with status code 400 - [object Object]"}}
```
which is not very helpful.
This PR should make it better.