### PR TITLE
Add TX status endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -417,6 +417,32 @@ We recommend querying using payment key hashes (`addr_vkh`) when possible (other
   ```
 </details>
 <details>
+  <summary>tx/status</summary>
+  This endpoint is used to return the current on-chain status of up to 100 transactions, given their ids. Currently, we return only the depth, meaning the number of blocks on top of the transactions
+
+  Input
+
+  ```
+  {
+    "ids": string[]
+  }
+  ```
+
+  Output: the `ids` sent in the request are transformed into keys under the `depth` field, and the value corresponding to this key will be the number of blocks on top of the transaction
+
+  ```
+  {
+    {
+      "depth": {
+        "<id>": number
+      }
+    }
+  }
+  ```
+
+
+</details>
+<details>
   <summary>status</summary>
 
   This endpoint is used to test whether or not the server can still be reached and get any manually flagged errors.

--- a/src/index.ts
+++ b/src/index.ts
@@ -26,6 +26,7 @@ import { handleGetAccountState } from "./services/accountState";
 import { handleGetRegHistory } from "./services/regHistory";
 import { handleGetRewardHistory } from "./services/rewardHistory";
 import { handleGetMultiAssetTxMintMetadata } from "./services/multiAssetTxMint";
+import { handleTxStatus } from "./services/txStatus";
 
 import { HealthChecker } from "./HealthChecker";
 
@@ -331,8 +332,13 @@ const routes : Route[] = [
     path: "/multiAsset/metadata",
     method: "post",
     handler: handleGetMultiAssetTxMintMetadata(pool)
-  }
-, { path: "/v2/importerhealthcheck"
+  },
+  {
+    path: "/tx/status",
+    method: "post",
+    handler: handleTxStatus(pool)
+  },
+  { path: "/v2/importerhealthcheck"
   , method: "get"
   , handler: async (_req: Request, res: Response) => {
     const status = healthChecker.getStatus();

--- a/src/services/txStatus.ts
+++ b/src/services/txStatus.ts
@@ -1,0 +1,37 @@
+import { Pool } from "pg";
+import { Request, Response } from "express";
+
+const txStatusQuery = `
+SELECT encode(tx.hash, 'hex') tx_id,
+       (highest_block.block_no - block.block_no + 1) depth
+FROM tx
+    INNER JOIN block on tx.block_id = block.id
+    CROSS JOIN (SELECT MAX(block_no) block_no FROM block) as highest_block
+WHERE encode(tx.hash, 'hex') = any(($1)::varchar array);
+`;
+
+export const handleTxStatus = (pool: Pool) => async (req: Request, res: Response) => {
+  if(!req.body || !req.body.ids) {
+    throw new Error("error, no tx ids informed.");
+  }
+  if (!Array.isArray(req.body.ids)) {
+    throw new Error("'ids' should be an array.");
+  }
+  const txIds: string[] = req.body.ids;
+  if (txIds.length > 100) {
+    throw new Error("Max limit of 100 tx ids exceeded.");
+  }
+  if (txIds.length === 0) {
+    throw new Error("error, at least 1 tx id should be informed.");
+  }
+
+  const result = await pool.query(txStatusQuery, [txIds]);
+
+  const depth: {[key: string]: number} = {};
+
+  for (const item of result.rows) {
+    depth[item.tx_id] = item.depth;
+  }
+
+  res.send({ depth });
+};


### PR DESCRIPTION
# Abstract
This PR adds the ednpoint `/tx/status` for returning the current depth of a set of transactions.

# Background
See the [task on Asana](https://app.asana.com/0/1200842454080452/1201208860580395).

# Implementation
The query simply calculates the TX depth by getting the current highest block and subtracting the number of the block in which the TX was included from it (and then summing `1`, so for TXs which are in the current block the returned depth is `1`).