### PR TITLE
Feature/safe block endpoint

### DIFF
--- a/config/default.ts
+++ b/config/default.ts
@@ -15,5 +15,6 @@ export default {
     txsHashesRequestLimit: 150,
     ogmiosAddress: process.env.OGMIOS_ADDRESS || "ogmios.waw.emurgo-rnd.com",
     ogmiosPort: process.env.OGMIOS_PORT || 1338
-  }
+  },
+  safeBlockDifference: process.env.SAFE_BLOCK_DIFFERENCE || "10"
 };

--- a/src/HealthChecker.ts
+++ b/src/HealthChecker.ts
@@ -1,5 +1,6 @@
 import { UtilEither } from "./utils";
 import * as BestBlock from "./services/bestblock";
+import { CardanoFrag } from "./Transactions/types";
 
 const REQUEST_RATE_MS = 2000;
 const REQUEST_TIMEOUT_MS = 5000;
@@ -13,14 +14,14 @@ export class HealthChecker {
   // is changing over time.  
   // If it is not, then we have an error!
 
-  healthCheckerFunc : () => Promise<UtilEither<BestBlock.CardanoFrag>>;
+  healthCheckerFunc : () => Promise<UtilEither<CardanoFrag>>;
 
-  lastBlock : UtilEither<BestBlock.CardanoFrag>;
+  lastBlock : UtilEither<CardanoFrag>;
   lastTime : number;
   lastGoodBlockChange : number;
-  timeAndBlock : [number, UtilEither<BestBlock.CardanoFrag>];
+  timeAndBlock : [number, UtilEither<CardanoFrag>];
 
-  constructor( bestBlockFunc : () => Promise<UtilEither<BestBlock.CardanoFrag>> ) {
+  constructor( bestBlockFunc : () => Promise<UtilEither<CardanoFrag>> ) {
     this.healthCheckerFunc = bestBlockFunc;
     const currentTime = Date.now();
 
@@ -34,7 +35,7 @@ export class HealthChecker {
   }
 
   checkHealth = async ():Promise<void> =>  {
-    let block : UtilEither<BestBlock.CardanoFrag> = { kind: "error", errMsg: "function failed" };
+    let block : UtilEither<CardanoFrag> = { kind: "error", errMsg: "function failed" };
     try {
       block = await this.healthCheckerFunc();
     } catch {

--- a/src/Transactions/types.ts
+++ b/src/Transactions/types.ts
@@ -3,6 +3,13 @@ import { Dictionary } from "../utils";
 export enum BlockEra { Byron = "byron"
                      , Shelley = "shelley"}
 
+export interface CardanoFrag {
+  epoch: number;
+  slot: number;
+  hash: string;
+  height: number;
+}
+
 export interface TransactionFrag {
     hash: string;
     fee: string;

--- a/src/index.ts
+++ b/src/index.ts
@@ -27,6 +27,7 @@ import { handleGetRegHistory } from "./services/regHistory";
 import { handleGetRewardHistory } from "./services/rewardHistory";
 import { handleGetMultiAssetTxMintMetadata } from "./services/multiAssetTxMint";
 import { handleTxStatus } from "./services/txStatus";
+import { handleSafeBlock } from "./services/safeBlock";
 
 import { HealthChecker } from "./HealthChecker";
 
@@ -294,6 +295,10 @@ const routes : Route[] = [
 , {   path: "/v2/bestblock"
   , method: "get"
   , handler: bestBlock(pool)
+}
+, {   path: "/v2/safeblock"
+  , method: "get"
+  , handler: handleSafeBlock(pool)
 }
 , { path: "/v2/addresses/filterUsed"
   , method: "post"

--- a/src/services/bestblock.ts
+++ b/src/services/bestblock.ts
@@ -2,12 +2,7 @@ import { Pool } from "pg";
 
 import { UtilEither} from "../utils";
 
-export interface CardanoFrag {
-  epoch: number;
-  slot: number;
-  hash: string;
-  height: number;
-}
+import { CardanoFrag } from "../Transactions/types";
 
 export const askBestBlock = async (pool: Pool) : Promise<UtilEither<CardanoFrag>> => {
   const query = `

--- a/src/services/safeBlock.ts
+++ b/src/services/safeBlock.ts
@@ -1,0 +1,30 @@
+import { Pool } from "pg";
+import { Request, Response } from "express";
+
+import { CardanoFrag } from "../Transactions/types";
+
+const safeBlockQuery = `SELECT epoch_no AS "epoch",
+    epoch_slot_no AS "slot",
+    encode(hash, 'hex') as hash,
+    block_no AS height
+FROM BLOCK
+WHERE block_no <= (SELECT MAX(block_no) FROM block) - 10
+ORDER BY id DESC
+LIMIT 1;
+`;
+
+export const handleSafeBlock = (pool: Pool) => async (req: Request, res: Response) => {
+    const result = await pool.query(safeBlockQuery);
+    if (result.rowCount === 0) throw new Error("no blocks found!");
+
+    const row = result.rows[0];
+
+    const safeBlock: CardanoFrag = {
+        epoch: row.epoch,
+        slot: row.slot,
+        hash: row.hash,
+        height: row.height
+    };
+
+    res.send(safeBlock);
+};

--- a/src/services/safeBlock.ts
+++ b/src/services/safeBlock.ts
@@ -19,7 +19,10 @@ export const handleSafeBlock = (pool: Pool) => async (req: Request, res: Respons
     const safeBlockDifference = parseInt(config.get("safeBlockDifference"));
 
     const result = await pool.query(safeBlockQuery, [safeBlockDifference]);
-    if (result.rowCount === 0) throw new Error(`Unable to determine safe block with the expected depth of: ${safeBlockDifference}!`);
+    if (result.rowCount === 0) {
+        res.send(undefined);
+        return;
+    }
 
     const row = result.rows[0];
 

--- a/src/services/safeBlock.ts
+++ b/src/services/safeBlock.ts
@@ -19,7 +19,7 @@ export const handleSafeBlock = (pool: Pool) => async (req: Request, res: Respons
     const safeBlockDifference = parseInt(config.get("safeBlockDifference"));
 
     const result = await pool.query(safeBlockQuery, [safeBlockDifference]);
-    if (result.rowCount === 0) throw new Error("no blocks found!");
+    if (result.rowCount === 0) throw new Error(`Unable to determine safe block with the expected depth of: ${safeBlockDifference}!`);
 
     const row = result.rows[0];
 


### PR DESCRIPTION
# Abstract
This PR adds a new endpoint to return the "Safe Block".

# Motivation
At #278 we add a new endpoint for returning a "snapshot" of the UTxO status for a series of addresses up to a certain block (reference block). The new endpoint to get the safe block included in this PR will often be used to get the reference block for the snapshot

# Background
See [this confluence page](https://emurgo.atlassian.net/wiki/spaces/CARDANO/pages/679706630/UTxO+API+Rework) for background.

# Implementation
Because the response from this endpoint is the same as the one from the "bestblock", we extract the `CardanoFrag` interface to the `types.ts` file, so we can use it in the safe block endpoint as well.
The query is very simple, we get the necessary columns to build the response and filter the blocks grater than the difference that we consider "safe", which is `10` by default, but can be changed via environment variable.