### PR TITLE
Add `/tipStatus` endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -404,6 +404,46 @@ We recommend querying using payment key hashes (`addr_vkh`) when possible (other
   ```
 </details>
 <details>
+  <summary>GET v2/tipStatus</summary>
+  Input
+
+  None (GET request)
+
+  Output
+
+  ```js
+  {
+    safeBlock: string,
+    bestBlock: string
+  }
+  ```
+</details>
+<details>
+  <summary>POST v2/tipStatus</summary>
+  Input
+
+  ```js
+  {
+    reference: {
+      bestBlocks: string[]
+    }
+  }
+  ```
+
+  Output
+
+  ```js
+  {
+    safeBlock: string,
+    bestBlock: string,
+    reference: {
+      lastFoundSafeBlock: string,
+      lastFoundBestBlock: string
+    }
+  }
+  ```
+</details>
+<details>
   <summary>txs/signed</summary>
   Input
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -28,6 +28,7 @@ import { handleGetRewardHistory } from "./services/rewardHistory";
 import { handleGetMultiAssetTxMintMetadata } from "./services/multiAssetTxMint";
 import { handleTxStatus } from "./services/txStatus";
 import { handleSafeBlock } from "./services/safeBlock";
+import { handleTipStatusGet, handleTipStatusPost } from "./services/tipStatus";
 
 import { HealthChecker } from "./HealthChecker";
 
@@ -299,6 +300,14 @@ const routes : Route[] = [
 , {   path: "/v2/safeblock"
   , method: "get"
   , handler: handleSafeBlock(pool)
+}
+, {   path: "/v2/tipStatus"
+  , method: "get"
+  , handler: handleTipStatusGet(pool)
+}
+, {   path: "/v2/tipStatus"
+  , method: "post"
+  , handler: handleTipStatusPost(pool)
 }
 , { path: "/v2/addresses/filterUsed"
   , method: "post"

--- a/src/services/tipStatus.ts
+++ b/src/services/tipStatus.ts
@@ -1,0 +1,100 @@
+import config from "config";
+
+import { Pool } from "pg";
+import { Request, Response } from "express";
+
+const safeBlockDifference = parseInt(config.get("safeBlockDifference"));
+
+const bestBlockQuery = `
+  SELECT epoch_no AS "epoch",
+    epoch_slot_no AS "slot",
+    encode(hash, 'hex') as hash,
+    block_no AS height
+  FROM BLOCK
+  ORDER BY id DESC
+  LIMIT 1;`;
+
+const safeBlockQuery = `SELECT epoch_no AS "epoch",
+  epoch_slot_no AS "slot",
+  encode(hash, 'hex') as hash,
+  block_no AS height
+FROM BLOCK
+WHERE block_no <= (SELECT MAX(block_no) FROM block) - ($1)::int
+ORDER BY id DESC
+LIMIT 1;
+`;
+
+const bestBlockFromReferenceQuery = `SELECT encode(hash, 'hex') as "hash", block_no as "blockNumber"
+    FROM block
+    WHERE encode(hash, 'hex') = any(($1)::varchar array)
+      AND block_no IS NOT NULL
+    ORDER BY block_no DESC
+    LIMIT 1`;
+
+const safeBlockFromReferenceQuery = `SELECT encode(hash, 'hex') as "hash", block_no as "blockNumber"
+  FROM block
+  WHERE encode(hash, 'hex') = any(($1)::varchar array)
+    AND block_no IS NOT NULL
+    AND block_no <= (SELECT MAX(block_no) FROM block) - ($2)::int
+  ORDER BY block_no DESC
+  LIMIT 1`;
+
+const getBestAndSafeBlocks = (pool: Pool) => async (): Promise<{
+  safeBlock: string | undefined,
+  bestBlock: string | undefined
+}> => {
+  const bestBlockResult = await pool.query(bestBlockQuery);
+  const safeBlockResult = await pool.query(safeBlockQuery, [safeBlockDifference]);
+
+  return {
+    safeBlock: safeBlockResult.rowCount > 0 ? safeBlockResult.rows[0].hash : undefined,
+    bestBlock: bestBlockResult.rowCount > 0 ? bestBlockResult.rows[0].hash : undefined,
+  };
+};
+
+export const handleTipStatusGet = (pool: Pool) => async (req: Request, res: Response) => {
+  const result = await getBestAndSafeBlocks(pool)();
+  res.send(result);
+};
+
+export const handleTipStatusPost = (pool: Pool) => async (req: Request, res: Response) => {
+  if (!req.body.reference) {
+    throw new Error("error, missing reference");
+  }
+
+  if (!req.body.reference.bestBlocks) {
+    throw new Error("error, missing bestBlocks inside reference");
+  }
+
+  const bestBlocks: string[] = req.body.reference.bestBlocks;
+  if (!Array.isArray(bestBlocks)) {
+    throw new Error("error, bestBlocks should be an array");
+  }
+
+  if (bestBlocks.length === 0) {
+    throw new Error("error, bestBlocks should not be empty");
+  }
+
+  const { safeBlock, bestBlock } = await getBestAndSafeBlocks(pool)();
+  
+  const bestBlockFromReferenceResult = await pool.query(bestBlockFromReferenceQuery, [bestBlocks]);
+  if (bestBlockFromReferenceResult.rowCount === 0) {
+    throw new Error("REFERENCE_POINT_BLOCK_NOT_FOUND");
+  }
+  const lastFoundBestBlock: string = bestBlockFromReferenceResult.rows[0].hash;
+
+  const safeBlockFromReferenceResult = await pool.query(safeBlockFromReferenceQuery, [bestBlocks, safeBlockDifference]);
+  if (safeBlockFromReferenceResult.rowCount === 0) {
+    throw new Error("REFERENCE_POINT_BLOCK_NOT_FOUND");
+  }
+  const lastFoundSafeBlock: string = safeBlockFromReferenceResult.rows[0].hash;
+
+  res.send({
+    safeBlock,
+    bestBlock,
+    reference: {
+      lastFoundSafeBlock,
+      lastFoundBestBlock
+    }
+  });
+};


### PR DESCRIPTION
# Abstract
This PR adds the `/tipStatus` endpoint for both `GET` and `POST` verbs.

# Motivation
We already have endpoints for returning the best block and the safe block. To minimize the number of requests during an UTxO sync, we create a single endpoint for returning both info.

# Background
See [this page](https://emurgo.atlassian.net/wiki/spaces/CARDANO/pages/679706630/UTxO+API+Rework?focusedCommentId=682459137#comment-682459137) detailing the UTxO endpoints rework