### PR TITLE
feat(oracles): add metadata oracle support

### DIFF
--- a/README.md
+++ b/README.md
@@ -694,3 +694,95 @@ We recommend querying using payment key hashes (`addr_vkh`) when possible (other
   }
   ```
 </details>
+<details>
+  <summary>/oracles/getDatapoints</summary>
+  This endpoint is used to return specific data (data point) of a specified oracle.
+
+  There are two usages of this endpoint - with and without source.
+  This is because when calling with source, ticker becomes mandatory.
+
+  1. without specifying source:
+
+  Input
+
+  ```js
+  {
+    addresses: Array<string>, // mandatory, bech32 addresses of trusted oracles
+    ticker?: string,  // optional. If not set, fetch all available tickers. If set, fetch only that ticker
+    blockNum?: number, // optional. If not set, fetch latest `count` data and order desc.
+    // If set, find `count` nearest (absolute) values around that block
+    // e.g. with block_no = 100, count = 3 and data at blocks 85,90,100,115,135, returned data will be for blocks:
+    // 100 (absolute distance 0), 90 (absolute distance 10) and 115 (absolute distance 15 - same as block 85, but more recent)
+    // i.e. nearest blocks to the block specified
+    // in case of a draw we display the more recent block
+    count?: number, // optional, default 1, max 10
+  }
+  ```
+
+  Output
+
+  ```js
+  [addresses: string]: undefined | {
+    blockDistance: number | null,
+    blockNumber: number,
+    txHash: string,
+    txIndex: number,
+    payload: any, // if a ticker is specified, then array of JSON with data,
+                 // if not specified then all tickers are returned in form of [ticker: string]: Array<any>
+  }
+  ```
+
+  2. with source (and thus also ticker) specified:
+
+  Input
+
+  ```js
+  {
+    addresses: Array<string>, // mandatory, bech32 addresses of trusted oracles
+    ticker: string,  // mandatory. When filtering with source, tickers are mandatory
+    blockNum?: number, // optional. If not set, fetch latest `count` data and order desc.
+    // If set, find `count` nearest (absolute) values around that block
+    // e.g. with block_no = 100, count = 3 and data at blocks 85,90,100,115,135, returned data will be for blocks:
+    // 100 (absolute distance 0), 90 (absolute distance 10) and 115 (absolute distance 15 - same as block 85, but more recent)
+    // i.e. nearest blocks to the block specified
+    // in case of a draw we display the more recent block
+    source: string, // mandatory. Source of the data
+    count?: number, // optional, default 1, max 10
+  }
+  ```
+
+  Output
+
+  ```js
+  [addresses: string]: undefined | {
+    blockDistance: number | null,
+    blockNumber: number,
+    txHash: string,
+    txIndex: number,
+    payload: any, // JSON with data
+  }
+  ```
+</details>
+<details>
+  <summary>/oracles/getTickers</summary>
+  This endpoint is used to return all available tickers of a specified array of oracles.
+
+  Input
+
+  ```js
+  {
+    addresses: Array<string>, // bech32 addresses of trusted oracles
+  }
+  ```
+
+  Output
+
+  ```js
+  [addresses: string]: undefined | {
+    Array<{
+      ticker: string,
+      latestBlock: number,
+    }>
+  }
+  ```
+</details>

--- a/src/index.ts
+++ b/src/index.ts
@@ -54,6 +54,9 @@ import { handleGetCardanoWalletPools } from "./services/cardanoWallet";
 import { handleMessageBoard } from "./services/messageBoard";
 import { handleMessageDirect } from "./services/messageDirect";
 
+import { handleOracleDatapoint } from "./services/oracleDatapoint";
+import { handleOracleTicker } from "./services/oracleTicker";
+
 import { mapTransactionFragsToResponse } from "./utils/mappers";
 
 const pool = new Pool({
@@ -344,6 +347,16 @@ const routes: Route[] = [
     path: "/messages/getMessageDirect",
     method: "post",
     handler: handleMessageDirect(pool),
+  },
+  {
+    path: "/oracles/getDatapoints",
+    method: "post",
+    handler: handleOracleDatapoint(pool),
+  },
+  {
+    path: "/oracles/getTickers",
+    method: "post",
+    handler: handleOracleTicker(pool),
   },
   {
     path: "/pool/cardanoWallet",

--- a/src/services/oracleDatapoint.ts
+++ b/src/services/oracleDatapoint.ts
@@ -8,7 +8,7 @@ interface Datapoint {
     blockDistance: number | null; // null if block parameter is not used
     txHash: string;
     txIndex: number;
-    payload: JSON;
+    payload: any;
   };
 }
 

--- a/src/services/oracleDatapoint.ts
+++ b/src/services/oracleDatapoint.ts
@@ -100,7 +100,7 @@ const queryMetadataOracle = `
             ELSE true
           END
           AND CASE
-            WHEN $3::INTEGER IS NOT NULL THEN block_no < $3 IS NOT NULL
+            WHEN $3::INTEGER IS NOT NULL THEN block_no < $3
             ELSE true
           END
         GROUP BY
@@ -223,7 +223,7 @@ const queryMetadataOracleSource = `
           AND txm.key = 1968
           AND (txm.json->$2) IS NOT NULL
           AND CASE
-            WHEN $3::INTEGER IS NOT NULL THEN block_no < $3 IS NOT NULL
+            WHEN $3::INTEGER IS NOT NULL THEN block_no < $3
             ELSE true
           END
           AND source->>'source' = $4

--- a/src/services/oracleDatapoint.ts
+++ b/src/services/oracleDatapoint.ts
@@ -46,7 +46,7 @@ const queryMetadataOracle = `
             ELSE true
           END
           AND CASE
-            WHEN $3::INTEGER IS NOT NULL THEN block_no >= $3 IS NOT NULL
+            WHEN $3::INTEGER IS NOT NULL THEN block_no >= $3
             ELSE true
           END
         GROUP BY
@@ -172,7 +172,7 @@ const queryMetadataOracleSource = `
           AND txm.key = 1968
           AND (txm.json->$2) IS NOT NULL
           AND CASE
-            WHEN $3::INTEGER IS NOT NULL THEN block_no >= $3 IS NOT NULL
+            WHEN $3::INTEGER IS NOT NULL THEN block_no >= $3
             ELSE true
           END
           AND source->>'source' = $4
@@ -276,7 +276,7 @@ export const handleOracleDatapoint =
   async (req: Request, res: Response): Promise<void> => {
     const addresses = req.body.addresses; // list of trusted oracles
     const ticker = req.body.ticker; // data point
-    const block = req.body.block; // block to which we should find the nearest data, in case of a draw we display newer
+    const blockNum = req.body.blockNum; // block to which we should find the nearest data, in case of a draw we display more recent block
     const source = req.body.source; // payload source
     const count = req.body.count; // number of total closest/most recent results, not per oracle. If you want per oracle results, query a single oracle address
 
@@ -289,14 +289,14 @@ export const handleOracleDatapoint =
     const metadataOracle = await p.query(queryMetadataOracle, [
       addresses, // mandatory, list of trusted oracles
       ticker, // optional. If not set, fetch all available tickers. If set, fetch only that ticker
-      block, // optional. If not set, fetch latest `count` data and order desc. If set, find `count` nearest values around that block
+      blockNum, // optional. If not set, fetch latest `count` data and order desc. If set, find `count` nearest values around that block
       count, // optional, default 1, max 10
     ]);
 
     const metadataOracleSource = await p.query(queryMetadataOracleSource, [
       addresses, // mandatory, list of trusted oracles,
       ticker, // mandatory. When filtering with source, tickers are mandatory
-      block, // optional. If not set, fetch latest `count` data and order desc. If set, find `count` nearest values around that block
+      blockNum, // optional. If not set, fetch latest `count` data and order desc. If set, find `count` nearest values around that block
       source, // mandatory. Source of the data
       count, // optional, default 1, max 10
     ]);

--- a/src/services/oracleDatapoint.ts
+++ b/src/services/oracleDatapoint.ts
@@ -1,0 +1,351 @@
+import { Pool } from "pg";
+
+import { Request, Response } from "express";
+
+export interface Datapoint {
+  [address: string]: {
+    blockNumber: number;
+    blockDistance: number | null; // null if block parameter is not used
+    txHash: string;
+    txIndex: number;
+    payload: JSON;
+  };
+}
+
+interface Dictionary<T> {
+  [addresses: string]: T;
+}
+
+export const handleOracleDatapoint =
+  (p: Pool) =>
+  async (req: Request, res: Response): Promise<void> => {
+    const addresses = req.body.addresses; // list of trusted oracles
+    const ticker = req.body.ticker; // data point
+    const block = req.body.block; // block to which we should find the nearest data, in case of a draw we display newer
+    const source = req.body.source; // payload source
+    const count = req.body.count; // number of total closest/most recent results, not per oracle. If you want per oracle results, query a single oracle address
+
+    if (!addresses || addresses.length === 0) {
+      throw new Error("Addresses of trusted oracles is missing");
+    }
+
+    const ret: Dictionary<Datapoint[]> = {};
+
+    const queryMetadataOracle = `
+      SELECT *
+      FROM
+        (
+          -- newer than queried block
+          (
+            SELECT
+              txo.address as "address",
+              b.block_no AS "blockNumber",
+              CASE
+                WHEN $3::INTEGER IS NOT NULL THEN (block_no - $3)
+              END AS "blockDistance",
+              encode(tx.hash, 'hex') AS "txHash",
+              tx.block_index AS "txIndex",
+              CASE
+                WHEN $2::TEXT IS NOT NULL THEN (txm.json->$2) -- if no ticker is specified, return all tickers
+                ELSE txm.json
+              END AS "payload"
+            FROM tx_out txo
+              JOIN tx_metadata txm ON (txo.tx_id = txm.tx_id)
+              JOIN tx ON (tx.id = txm.tx_id)
+              JOIN block b ON (b.id = tx.block_id)
+            WHERE
+              txo.address = ANY ($1)
+              AND txm.key = 1968
+              AND CASE
+                WHEN $2::TEXT IS NOT NULL THEN (txm.json->$2) IS NOT NULL
+                ELSE true
+              END
+              AND CASE
+                WHEN $3::INTEGER IS NOT NULL THEN block_no >= $3 IS NOT NULL
+                ELSE true
+              END
+            GROUP BY
+              txo.address,
+              tx.hash,
+              b.block_no,
+              tx.block_index,
+              txm.json
+            ORDER BY (
+                CASE
+                  WHEN $3::INTEGER IS NOT NULL THEN (block_no - $3)
+                END
+              ) ASC,
+              -- if a block is specified, order by nearest first
+              (
+                CASE
+                  WHEN $3::INTEGER IS NULL THEN block_no
+                END
+              ) DESC -- if a block is not specified, order by newest data
+            LIMIT CASE
+                -- default limit to 1 result, max 10
+                WHEN $4 >= 1
+                AND $4 <= 10 THEN $4
+                ELSE 1
+              END
+          )
+          UNION
+          -- older than queried block
+          (
+            SELECT
+              txo.address as "address",
+              b.block_no AS "blockNumber",
+              CASE
+                WHEN $3::INTEGER IS NOT NULL THEN ($3 - block_no)
+              END AS "blockDistance",
+              encode(tx.hash, 'hex') AS "txHash",
+              tx.block_index AS "txIndex",
+              CASE
+                WHEN $2::TEXT IS NOT NULL THEN (txm.json->$2) -- if no ticker is specified, return all tickers
+                ELSE txm.json
+              END AS "payload"
+            FROM tx_out txo
+              JOIN tx_metadata txm ON (txo.tx_id = txm.tx_id)
+              JOIN tx ON (tx.id = txm.tx_id)
+              JOIN block b ON (b.id = tx.block_id)
+            WHERE
+              txo.address = ANY ($1)
+              AND txm.key = 1968
+              AND CASE
+                WHEN $2::TEXT IS NOT NULL THEN (txm.json->$2) IS NOT NULL
+                ELSE true
+              END
+              AND CASE
+                WHEN $3::INTEGER IS NOT NULL THEN block_no < $3 IS NOT NULL
+                ELSE true
+              END
+            GROUP BY
+              txo.address,
+              tx.hash,
+              b.block_no,
+              tx.block_index,
+              txm.json
+            ORDER BY (
+                CASE
+                  WHEN $3::INTEGER IS NOT NULL THEN ABS($3 - block_no)
+                END
+              ) ASC,
+              -- if a block is specified, order by nearest first
+              (
+                CASE
+                  WHEN $3::INTEGER IS NULL THEN block_no
+                END
+              ) DESC -- if a block is not specified, order by newest data
+            LIMIT CASE
+                -- default limit to 1 result, max 10
+                WHEN $4 >= 1
+                AND $4 <= 10 THEN $4
+                ELSE 1
+              END
+          )
+        ) AS "nearest_datapoints"
+      ORDER BY (
+          CASE
+            WHEN $3::INTEGER IS NOT NULL THEN ABS($3 - "blockNumber")
+          END
+        ) ASC, "blockNumber" DESC,
+        -- if a block is specified, order by nearest first
+        (
+          CASE
+            WHEN $3::INTEGER IS NULL THEN "blockNumber"
+          END
+        ) DESC -- if a block is not specified, order by newest data
+      LIMIT CASE
+          -- default limit to 1 result, max 10
+          WHEN $4 >= 1
+          AND $4 <= 10 THEN $4
+          ELSE 1
+        END
+    `;
+
+    const queryMetadataOracleSource = `
+      SELECT *
+      FROM
+        (
+          -- newer than queried block
+          (
+            SELECT
+              txo.address as "address",
+              b.block_no AS "blockNumber",
+              CASE
+                WHEN $3::INTEGER IS NOT NULL THEN (block_no - $3)
+              END AS "blockDistance",
+              encode(tx.hash, 'hex') AS "txHash",
+              tx.block_index AS "txIndex",
+              source AS "payload"
+            FROM tx_out txo
+              JOIN tx_metadata txm ON (txo.tx_id = txm.tx_id)
+              JOIN tx ON (tx.id = txm.tx_id)
+              JOIN block b ON (b.id = tx.block_id)
+              CROSS JOIN jsonb_array_elements(txm.json->$2) source
+            WHERE
+              txo.address = ANY ($1)
+              AND txm.key = 1968
+              AND (txm.json->$2) IS NOT NULL
+              AND CASE
+                WHEN $3::INTEGER IS NOT NULL THEN block_no >= $3 IS NOT NULL
+                ELSE true
+              END
+              AND source->>'source' = $4
+            GROUP BY
+              txo.address,
+              tx.hash,
+              b.block_no,
+              tx.block_index,
+              txm.json,
+              source.*
+            ORDER BY (
+                CASE
+                  WHEN $3::INTEGER IS NOT NULL THEN (block_no - $3)
+                END
+              ) ASC,
+              -- if a block is specified, order by nearest first
+              (
+                CASE
+                  WHEN $3::INTEGER IS NULL THEN block_no
+                END
+              ) DESC -- if a block is not specified, order by newest data
+            LIMIT CASE
+                -- default limit to 1 result, max 10
+                WHEN $5 >= 1
+                AND $5 <= 10 THEN $5
+                ELSE 1
+              END
+          )
+          UNION
+          -- older than queried block
+          (
+            SELECT
+              txo.address as "address",
+              b.block_no AS "blockNumber",
+              CASE
+                WHEN $3::INTEGER IS NOT NULL THEN (block_no - $3)
+              END AS "blockDistance",
+              encode(tx.hash, 'hex') AS "txHash",
+              tx.block_index AS "txIndex",
+              source AS "payload"
+            FROM tx_out txo
+              JOIN tx_metadata txm ON (txo.tx_id = txm.tx_id)
+              JOIN tx ON (tx.id = txm.tx_id)
+              JOIN block b ON (b.id = tx.block_id)
+              CROSS JOIN jsonb_array_elements(txm.json->$2) source
+            WHERE
+              txo.address = ANY ($1)
+              AND txm.key = 1968
+              AND (txm.json->$2) IS NOT NULL
+              AND CASE
+                WHEN $3::INTEGER IS NOT NULL THEN block_no < $3 IS NOT NULL
+                ELSE true
+              END
+              AND source->>'source' = $4
+            GROUP BY
+              txo.address,
+              tx.hash,
+              b.block_no,
+              tx.block_index,
+              source.*
+            ORDER BY (
+                CASE
+                  WHEN $3::INTEGER IS NOT NULL THEN ABS($3 - block_no)
+                END
+              ) ASC,
+              -- if a block is specified, order by nearest first
+              (
+                CASE
+                  WHEN $3::INTEGER IS NULL THEN block_no
+                END
+              ) DESC -- if a block is not specified, order by newest data
+            LIMIT CASE
+                -- default limit to 1 result, max 10
+                WHEN $5 >= 1
+                AND $5 <= 10 THEN $5
+                ELSE 1
+              END
+          )
+        ) AS "nearest_datapoints"
+      ORDER BY (
+          CASE
+            WHEN $3::INTEGER IS NOT NULL THEN ABS($3 - "blockNumber")
+          END
+        ) ASC, "blockNumber" DESC,
+        -- if a block is specified, order by nearest first
+        (
+          CASE
+            WHEN $3::INTEGER IS NULL THEN "blockNumber"
+          END
+        ) DESC -- if a block is not specified, order by newest data
+      LIMIT CASE
+          -- default limit to 1 result, max 10
+          WHEN $5 >= 1
+          AND $5 <= 10 THEN $5
+          ELSE 1
+        END
+    `;
+
+    const metadataOracle = await p.query(queryMetadataOracle, [
+      addresses, // mandatory, list of trusted oracles
+      ticker, // optional. If not set, fetch all available tickers. If set, fetch only that ticker
+      block, // optional. If not set, fetch latest `count` data and order desc. If set, find `count` nearest values around that block
+      count, // optional, default 1, max 10
+    ]);
+
+    const metadataOracleSource = await p.query(queryMetadataOracleSource, [
+      addresses, // mandatory, list of trusted oracles,
+      ticker, // mandatory. When filtering with source, tickers are mandatory
+      block, // optional. If not set, fetch latest `count` data and order desc. If set, find `count` nearest values around that block
+      source, // mandatory. Source of the data
+      count, // optional, default 1, max 10
+    ]);
+
+    // if source is defined we have to use a separate query
+    if (source) {
+      if (!ticker || !source) {
+        // tickers HAVE to be defined as well
+        throw new Error(
+          "Both ticker and source must be defined when filtering by source"
+        );
+      }
+
+      metadataOracleSource.rows.map(async (datapoint) => {
+        try {
+          if (!ret[datapoint.address]) {
+            ret[datapoint.address] = new Array<Datapoint>();
+          }
+
+          ret[datapoint.address].push({
+            blockDistance: datapoint.blockDistance,
+            blockNumber: datapoint.blockNumber,
+            txHash: datapoint.txHash,
+            txIndex: datapoint.txIndex,
+            payload: datapoint.payload,
+          });
+        } catch (err) {
+          console.log("Error when processing oracle datapoints. Message:", err);
+        }
+      });
+    } else {
+      metadataOracle.rows.map(async (datapoint) => {
+        try {
+          if (!ret[datapoint.address]) {
+            ret[datapoint.address] = new Array<Datapoint>();
+          }
+
+          ret[datapoint.address].push({
+            blockDistance: datapoint.blockDistance,
+            blockNumber: datapoint.blockNumber,
+            txHash: datapoint.txHash,
+            txIndex: datapoint.txIndex,
+            payload: datapoint.payload,
+          });
+        } catch (err) {
+          console.log("Error when processing oracle datapoints. Message:", err);
+        }
+      });
+    }
+
+    res.send(ret);
+  };

--- a/src/services/oracleTicker.ts
+++ b/src/services/oracleTicker.ts
@@ -1,0 +1,69 @@
+import { Pool } from "pg";
+
+import { Request, Response } from "express";
+
+export interface Ticker {
+  [address: string]: {
+    ticker: string;
+    latestBlock: number;
+  };
+}
+
+interface Dictionary<T> {
+  [addresses: string]: T;
+}
+
+export const handleOracleTicker =
+  (p: Pool) =>
+  async (req: Request, res: Response): Promise<void> => {
+    const addresses = req.body.addresses; // list of trusted oracles
+
+    if (!addresses || addresses.length === 0) {
+      throw new Error("Addresses of trusted oracles is missing");
+    }
+
+    const ret: Dictionary<Ticker[]> = {};
+
+    const queryMetadataOracle = `
+      SELECT
+        keys.address AS "address",
+        keys.ticker AS "ticker",
+        (
+          SELECT b.block_no AS "latestBlock"
+          FROM tx
+            JOIN block b ON (b.id = tx.block_id)
+          WHERE tx.id = latest
+        ) AS "latestBlock"
+      FROM (
+          SELECT
+            txo.address AS "address",
+            jsonb_object_keys(txm.json) AS "ticker",
+            MAX(txm.tx_id) AS "latest"
+          FROM tx_out txo
+            JOIN tx_metadata txm ON (txo.tx_id = txm.tx_id)
+          WHERE txo.address = ANY ($1)
+            AND txm.key = 1968
+          GROUP BY ticker,
+            txo.address
+        ) AS "keys"
+    `;
+
+    const oracleTickers = await p.query(queryMetadataOracle, [addresses]);
+    console.log(oracleTickers);
+    oracleTickers.rows.map(async (oracleTicker) => {
+      try {
+        if (!ret[oracleTicker.address]) {
+          ret[oracleTicker.address] = new Array<Ticker>();
+        }
+
+        ret[oracleTicker.address].push({
+          ticker: oracleTicker.ticker,
+          latestBlock: oracleTicker.latestBlock,
+        });
+      } catch (err) {
+        console.log("Error when processing oracle tickers. Message:", err);
+      }
+    });
+
+    res.send(ret);
+  };

--- a/src/services/oracleTicker.ts
+++ b/src/services/oracleTicker.ts
@@ -50,7 +50,6 @@ export const handleOracleTicker =
     const ret: Dictionary<Ticker[]> = {};
 
     const oracleTickers = await p.query(queryMetadataOracle, [addresses]);
-    console.log(oracleTickers);
     oracleTickers.rows.map(async (oracleTicker) => {
       try {
         if (!ret[oracleTicker.address]) {

--- a/tests/getOracleDatapoints.test.ts
+++ b/tests/getOracleDatapoints.test.ts
@@ -8,7 +8,7 @@ const testableUri = endpoint + "oracles/getDatapoints";
 const oracleAddress = [
   "addr1q85yx2w7ragn5sx6umgmtjpc3865s9sg59sz4rrh6f90kgwfwlzu3w8ttacqg89mkdgwshwnplj5c5n9f8dhp0h55q2q7qm63t",
 ];
-const block = 5746926;
+const blockNum = 5746926;
 const oracleAddresses = [
   "addr1q85yx2w7ragn5sx6umgmtjpc3865s9sg59sz4rrh6f90kgwfwlzu3w8ttacqg89mkdgwshwnplj5c5n9f8dhp0h55q2q7qm63t",
   "addr1v8w6wfzljnzdrwq6patkas35pgjzc3xlggpz70kaldsetcsrw3ep4",
@@ -47,7 +47,7 @@ describe("/oracles/getDatapoints", function () {
       url: testableUri,
       data: {
         addresses: oracleAddresses,
-        block: block,
+        blockNum: blockNum,
         count: count,
       },
     });
@@ -130,7 +130,7 @@ describe("/oracles/getDatapoints", function () {
       url: testableUri,
       data: {
         addresses: oracleAddresses,
-        block: block,
+        blockNum: blockNum,
         ticker: ticker,
         source: source,
         count: count,

--- a/tests/getOracleDatapoints.test.ts
+++ b/tests/getOracleDatapoints.test.ts
@@ -1,0 +1,185 @@
+import axios from "axios";
+import { expect } from "chai";
+import { config } from "./config";
+
+const endpoint = config.apiUrl;
+const testableUri = endpoint + "oracles/getDatapoints";
+
+const oracleAddress = [
+  "addr1q85yx2w7ragn5sx6umgmtjpc3865s9sg59sz4rrh6f90kgwfwlzu3w8ttacqg89mkdgwshwnplj5c5n9f8dhp0h55q2q7qm63t",
+];
+const block = 5746926;
+const oracleAddresses = [
+  "addr1q85yx2w7ragn5sx6umgmtjpc3865s9sg59sz4rrh6f90kgwfwlzu3w8ttacqg89mkdgwshwnplj5c5n9f8dhp0h55q2q7qm63t",
+  "addr1v8w6wfzljnzdrwq6patkas35pgjzc3xlggpz70kaldsetcsrw3ep4",
+];
+const count = 3;
+const ticker = "ADAEUR";
+const source = "coinGecko";
+
+describe("/oracles/getDatapoints", function () {
+  it("should return all latest datapoints", async () => {
+    const result = await axios({
+      method: "post",
+      url: testableUri,
+      data: {
+        addresses: oracleAddress,
+        count: count,
+      },
+    });
+    expect(result.data).not.be.empty;
+    expect(result.data).to.have.property(oracleAddress[0]);
+    expect(result.data[oracleAddress[0]]).to.be.an("array").that.is.not.empty;
+    expect(result.data[oracleAddress[0]][0]).to.have.property("blockDistance");
+    expect(result.data[oracleAddress[0]][0]).to.have.property("blockNumber");
+    expect(result.data[oracleAddress[0]][0]).to.have.property("txHash");
+    expect(result.data[oracleAddress[0]][0]).to.have.property("txIndex");
+    expect(result.data[oracleAddress[0]][0]).to.have.property("payload");
+
+    expect(result.data[oracleAddress[0]][0].blockDistance).to.be.a("null");
+    expect(result.data[oracleAddress[0]][0].blockNumber).to.be.a("number");
+    expect(result.data[oracleAddress[0]][0].txHash).to.be.a("string");
+    expect(result.data[oracleAddress[0]][0].txIndex).to.be.a("number");
+  });
+  it("should return all datapoints near a specific block", async () => {
+    const result = await axios({
+      method: "post",
+      url: testableUri,
+      data: {
+        addresses: oracleAddresses,
+        block: block,
+        count: count,
+      },
+    });
+    expect(result.data).not.be.empty;
+    expect(result.data).to.have.property(oracleAddresses[1]);
+    expect(result.data).to.have.property(oracleAddresses[0]);
+    expect(result.data[oracleAddresses[0]]).to.be.an("array").that.is.not.empty;
+    expect(result.data[oracleAddresses[1]]).to.be.an("array").that.is.not.empty;
+
+    expect(result.data[oracleAddresses[0]][0]).to.have.property(
+      "blockDistance"
+    );
+    expect(result.data[oracleAddresses[0]][0]).to.have.property("blockNumber");
+    expect(result.data[oracleAddresses[0]][0]).to.have.property("txHash");
+    expect(result.data[oracleAddresses[0]][0]).to.have.property("txIndex");
+    expect(result.data[oracleAddresses[0]][0]).to.have.property("payload");
+
+    expect(result.data[oracleAddresses[1]][0]).to.have.property(
+      "blockDistance"
+    );
+    expect(result.data[oracleAddresses[1]][0]).to.have.property("blockNumber");
+    expect(result.data[oracleAddresses[1]][0]).to.have.property("txHash");
+    expect(result.data[oracleAddresses[1]][0]).to.have.property("txIndex");
+    expect(result.data[oracleAddresses[1]][0]).to.have.property("payload");
+
+    expect(result.data[oracleAddresses[0]][0].blockDistance).to.be.a("number");
+    expect(result.data[oracleAddresses[0]][0].blockNumber).to.be.a("number");
+    expect(result.data[oracleAddresses[0]][0].txHash).to.be.a("string");
+    expect(result.data[oracleAddresses[0]][0].txIndex).to.be.a("number");
+
+    expect(result.data[oracleAddresses[1]][0].blockDistance).to.be.a("number");
+    expect(result.data[oracleAddresses[1]][0].blockNumber).to.be.a("number");
+    expect(result.data[oracleAddresses[1]][0].txHash).to.be.a("string");
+    expect(result.data[oracleAddresses[1]][0].txIndex).to.be.a("number");
+
+    expect(
+      result.data[oracleAddresses[0]][0].payload["ADABTC"][0].value
+    ).to.be.equal("4.096e-05");
+    expect(
+      result.data[oracleAddresses[0]][0].payload["ADABTC"][0].source
+    ).to.be.equal("coinGecko");
+  });
+  it("should return all sources of a specific ticker", async () => {
+    const result = await axios({
+      method: "post",
+      url: testableUri,
+      data: {
+        addresses: oracleAddress,
+        ticker: ticker,
+        count: count,
+      },
+    });
+    expect(result.data).not.be.empty;
+    expect(result.data).to.have.property(oracleAddress[0]);
+    expect(result.data[oracleAddress[0]]).to.be.an("array").that.is.not.empty;
+
+    expect(result.data[oracleAddress[0]][0]).to.have.property("blockDistance");
+    expect(result.data[oracleAddress[0]][0]).to.have.property("blockNumber");
+    expect(result.data[oracleAddress[0]][0]).to.have.property("txHash");
+    expect(result.data[oracleAddress[0]][0]).to.have.property("txIndex");
+    expect(result.data[oracleAddress[0]][0]).to.have.property("payload");
+
+    expect(result.data[oracleAddress[0]][0]).to.have.property("blockDistance");
+
+    expect(result.data[oracleAddresses[0]][0].blockDistance).to.be.a("null");
+    expect(result.data[oracleAddresses[0]][0].blockNumber).to.be.a("number");
+    expect(result.data[oracleAddresses[0]][0].txHash).to.be.a("string");
+    expect(result.data[oracleAddresses[0]][0].txIndex).to.be.a("number");
+
+    expect(result.data[oracleAddresses[0]][0].payload[0].value).to.be.a(
+      "string"
+    );
+    expect(result.data[oracleAddresses[0]][0].payload[0].source).to.be.a(
+      "string"
+    );
+  });
+  it("should return specific source of a specific ticker near a block", async () => {
+    const result = await axios({
+      method: "post",
+      url: testableUri,
+      data: {
+        addresses: oracleAddresses,
+        block: block,
+        ticker: ticker,
+        source: source,
+        count: count,
+      },
+    });
+    expect(result.data).not.be.empty;
+    expect(result.data).to.have.property(oracleAddresses[1]);
+    expect(result.data).to.have.property(oracleAddresses[0]);
+    expect(result.data[oracleAddresses[0]]).to.be.an("array").that.is.not.empty;
+    expect(result.data[oracleAddresses[1]]).to.be.an("array").that.is.not.empty;
+
+    expect(result.data[oracleAddresses[0]][0]).to.have.property(
+      "blockDistance"
+    );
+    expect(result.data[oracleAddresses[0]][0]).to.have.property("blockNumber");
+    expect(result.data[oracleAddresses[0]][0]).to.have.property("txHash");
+    expect(result.data[oracleAddresses[0]][0]).to.have.property("txIndex");
+    expect(result.data[oracleAddresses[0]][0]).to.have.property("payload");
+
+    expect(result.data[oracleAddresses[1]][0]).to.have.property(
+      "blockDistance"
+    );
+    expect(result.data[oracleAddresses[1]][0]).to.have.property("blockNumber");
+    expect(result.data[oracleAddresses[1]][0]).to.have.property("txHash");
+    expect(result.data[oracleAddresses[1]][0]).to.have.property("txIndex");
+    expect(result.data[oracleAddresses[1]][0]).to.have.property("payload");
+
+    expect(result.data[oracleAddresses[0]][0].blockDistance).to.be.a("number");
+    expect(result.data[oracleAddresses[0]][0].blockNumber).to.be.a("number");
+    expect(result.data[oracleAddresses[0]][0].txHash).to.be.a("string");
+    expect(result.data[oracleAddresses[0]][0].txIndex).to.be.a("number");
+
+    expect(result.data[oracleAddresses[1]][0].blockDistance).to.be.a("number");
+    expect(result.data[oracleAddresses[1]][0].blockNumber).to.be.a("number");
+    expect(result.data[oracleAddresses[1]][0].txHash).to.be.a("string");
+    expect(result.data[oracleAddresses[1]][0].txIndex).to.be.a("number");
+
+    expect(result.data[oracleAddresses[0]][0].payload.value).to.be.equal(
+      "1.37"
+    );
+    expect(result.data[oracleAddresses[0]][0].payload.source).to.be.equal(
+      "coinGecko"
+    );
+
+    expect(result.data[oracleAddresses[1]][0].payload.value).to.be.equal(
+      "1.36"
+    );
+    expect(result.data[oracleAddresses[1]][0].payload.source).to.be.equal(
+      "coinGecko"
+    );
+  });
+});

--- a/tests/getOracleTickers.test.ts
+++ b/tests/getOracleTickers.test.ts
@@ -1,0 +1,48 @@
+import axios from "axios";
+import { expect } from "chai";
+import { config } from "./config";
+
+const endpoint = config.apiUrl;
+const testableUri = endpoint + "oracles/getTickers";
+
+const oracleAddress = [
+  "addr1q85yx2w7ragn5sx6umgmtjpc3865s9sg59sz4rrh6f90kgwfwlzu3w8ttacqg89mkdgwshwnplj5c5n9f8dhp0h55q2q7qm63t",
+];
+const oracleAddresses = [
+  "addr1q85yx2w7ragn5sx6umgmtjpc3865s9sg59sz4rrh6f90kgwfwlzu3w8ttacqg89mkdgwshwnplj5c5n9f8dhp0h55q2q7qm63t",
+  "addr1v8w6wfzljnzdrwq6patkas35pgjzc3xlggpz70kaldsetcsrw3ep4",
+];
+
+describe("/oracles/getTickers", function () {
+  it("should return tickers", async () => {
+    const result = await axios({
+      method: "post",
+      url: testableUri,
+      data: {
+        addresses: oracleAddress,
+      },
+    });
+    expect(result.data).not.be.empty;
+    expect(result.data).to.have.property(oracleAddress[0]);
+    expect(result.data[oracleAddress[0]]).to.be.an("array").that.is.not.empty;
+    expect(result.data[oracleAddress[0]][0]).to.have.property("ticker");
+    expect(result.data[oracleAddress[0]][0].ticker).to.be.a("string");
+    expect(result.data[oracleAddress[0]][0].latestBlock).to.be.a("number");
+  });
+
+  it("should return multiple tickers", async () => {
+    const result = await axios({
+      method: "post",
+      url: testableUri,
+      data: {
+        addresses: oracleAddresses,
+      },
+    });
+    expect(result.data).not.be.empty;
+    expect(result.data).to.have.property(oracleAddresses[1]);
+    expect(result.data[oracleAddresses[1]]).to.be.an("array").that.is.not.empty;
+    expect(result.data[oracleAddresses[1]][0]).to.have.property("ticker");
+    expect(result.data[oracleAddresses[1]][0].ticker).to.be.a("string");
+    expect(result.data[oracleAddresses[1]][0].latestBlock).to.be.a("number");
+  });
+});


### PR DESCRIPTION
This is part of the Catalyst project funded effort to provide access to metadata oracles datapoints in Yoroi.

This PR implements:
* getting all tickers of queried oracles (their addresses)
* getting relevant datapoints with many filtering options (by ticker, by ticker&source, by block proximity or by latest data)

Thanks!!!