### PR TITLE
Add endpoint for NFT image validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -545,3 +545,31 @@ We recommend querying using payment key hashes (`addr_vkh`) when possible (other
   }
   ```
 </details>
+
+<details>
+  <summary>multiAsset/validateNFT/:fingerprint</summary>
+  Retrieves image from an NFT and validates it. In case this was already done for the given NFT, simply return the validation results
+
+  Input
+
+  None (GET request)
+
+  Outputs:
+
+  ***200 OK*** (when the validation already happened)
+  ```js
+  {
+    smallVariantFile: string,
+    largeVariantFile: string,
+    contentsOnImage: string[],
+    category: 'GREEN' | 'YELLOW' | 'RED',
+    validated: boolean
+  }
+  ```
+
+  ***204 No Content*** (when NFT is sent for validation)
+  ```js
+  {
+  }
+  ```
+</details>

--- a/README.md
+++ b/README.md
@@ -960,11 +960,10 @@ We recommend querying using payment key hashes (`addr_vkh`) when possible (other
   ***200 OK*** (when the validation already happened)
   ```js
   {
-    smallVariantFile: string,
-    largeVariantFile: string,
-    contentsOnImage: string[],
-    category: 'GREEN' | 'YELLOW' | 'RED',
-    validated: boolean
+    status: string,
+    contents: Array<string>,
+    originalStatus: string,
+    thirdPartyReport: any
   }
   ```
 

--- a/config/default.ts
+++ b/config/default.ts
@@ -16,5 +16,11 @@ export default {
     ogmiosAddress: process.env.OGMIOS_ADDRESS || "ogmios.waw.emurgo-rnd.com",
     ogmiosPort: process.env.OGMIOS_PORT || 1338
   },
+  aws: {
+    lambdaEndpoint: process.env.LAMBDA_ENDPOINT || "",
+    accessKeyId: process.env.AWS_ACCESS_KEY_ID || "",
+    secretAccessKey: process.env.AWS_SECRET_ACCESS_KEY || "",
+    region: process.env.AWS_REGION ?? ""
+  },
   safeBlockDifference: process.env.SAFE_BLOCK_DIFFERENCE || "10"
 };

--- a/config/default.ts
+++ b/config/default.ts
@@ -18,9 +18,11 @@ export default {
   safeBlockDifference: process.env.SAFE_BLOCK_DIFFERENCE || "10",
   usingQueueEndpoint: process.env.USE_SIGNED_TX_QUEUE || "false",
   aws: {
-    lambdaEndpoint: process.env.LAMBDA_ENDPOINT || "",
+    lambda: {
+      nftValidator: process.env.NFT_VALIDATOR_LAMBDA || "devNftValidatorLambda"
+    },
     accessKeyId: process.env.AWS_ACCESS_KEY_ID || "",
     secretAccessKey: process.env.AWS_SECRET_ACCESS_KEY || "",
-    region: process.env.AWS_REGION ?? ""
+    region: process.env.AWS_REGION || "eu-central-1"
   },
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -2559,11 +2559,6 @@
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA="
     },
-    "isomorphic-ws": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/isomorphic-ws/-/isomorphic-ws-4.0.1.tgz",
-      "integrity": "sha512-BhBvN2MBpWTaSHdWRb/bwdZJ1WaehQ2L1KngkCkfLUGF0mAWAT1sQUQacEmQ0jXkFw/czDXPNQSL5u2/Krsz1w=="
-    },
     "jmespath": {
       "version": "0.15.0",
       "resolved": "https://registry.npmjs.org/jmespath/-/jmespath-0.15.0.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "yoroi-cardano-backend",
-  "version": "2.3.6",
+  "version": "2.3.8",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "yoroi-cardano-backend",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -946,6 +946,34 @@
         }
       }
     },
+    "aws-sdk": {
+      "version": "2.1036.0",
+      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.1036.0.tgz",
+      "integrity": "sha512-K0f4uXL32ZdoPmWiuSQEAC5ae5v7gNmhjzoEB7VonE5E8l2umWsoU0Ahm8WPr14LgsvtkeyBuqBjphbxLz6hIw==",
+      "requires": {
+        "buffer": "4.9.2",
+        "events": "1.1.1",
+        "ieee754": "1.1.13",
+        "jmespath": "0.15.0",
+        "querystring": "0.2.0",
+        "sax": "1.2.1",
+        "url": "0.10.3",
+        "uuid": "3.3.2",
+        "xml2js": "0.4.19"
+      },
+      "dependencies": {
+        "sax": {
+          "version": "1.2.1",
+          "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.1.tgz",
+          "integrity": "sha1-e45lYZCyKOgaZq6nSEgNgozS03o="
+        },
+        "uuid": {
+          "version": "3.3.2",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
+          "integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA=="
+        }
+      }
+    },
     "axios": {
       "version": "0.21.1",
       "resolved": "https://registry.npmjs.org/axios/-/axios-0.21.1.tgz",
@@ -958,6 +986,11 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
       "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
+    },
+    "base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="
     },
     "bech32": {
       "version": "1.1.4",
@@ -1024,6 +1057,16 @@
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.1.tgz",
       "integrity": "sha512-qhAVI1+Av2X7qelOfAIYwXONood6XlZE/fXaBSmW/T5SzLAmCgzi+eiWE7fUvbHaeNBQH13UftjpXxsfLkMpgw=="
+    },
+    "buffer": {
+      "version": "4.9.2",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-4.9.2.tgz",
+      "integrity": "sha512-xq+q3SRMOxGivLhBNaUdC64hDTQwejJ+H0T/NB1XMtTVEwNTrfFF3gAxiyW0Bu/xWEGhjVKgUcMhCrUy2+uCWg==",
+      "requires": {
+        "base64-js": "^1.0.2",
+        "ieee754": "^1.1.4",
+        "isarray": "^1.0.0"
+      }
     },
     "buffer-from": {
       "version": "1.1.1",
@@ -1979,6 +2022,11 @@
       "resolved": "https://registry.npmjs.org/eventemitter2/-/eventemitter2-5.0.1.tgz",
       "integrity": "sha1-YZegldX7a1folC9v1+qtY6CclFI="
     },
+    "events": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/events/-/events-1.1.1.tgz",
+      "integrity": "sha1-nr23Y1rQmccNzEwqH1AEKI6L2SQ="
+    },
     "express": {
       "version": "5.0.0-alpha.8",
       "resolved": "https://registry.npmjs.org/express/-/express-5.0.0-alpha.8.tgz",
@@ -2431,6 +2479,11 @@
         "safer-buffer": ">= 2.1.2 < 3"
       }
     },
+    "ieee754": {
+      "version": "1.1.13",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.13.tgz",
+      "integrity": "sha512-4vf7I2LYV/HaWerSo3XmlMkp5eZ83i+/CDluXi/IGTs/O1sejBNhTtnxzmRZfvOUqj7lZjqHkeTvpgSFDlWZTg=="
+    },
     "ignore": {
       "version": "4.0.6",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-4.0.6.tgz",
@@ -2555,6 +2608,11 @@
         "has-symbols": "^1.0.1"
       }
     },
+    "isarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
+    },
     "isexe": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
@@ -2564,6 +2622,11 @@
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/isomorphic-ws/-/isomorphic-ws-4.0.1.tgz",
       "integrity": "sha512-BhBvN2MBpWTaSHdWRb/bwdZJ1WaehQ2L1KngkCkfLUGF0mAWAT1sQUQacEmQ0jXkFw/czDXPNQSL5u2/Krsz1w=="
+    },
+    "jmespath": {
+      "version": "0.15.0",
+      "resolved": "https://registry.npmjs.org/jmespath/-/jmespath-0.15.0.tgz",
+      "integrity": "sha1-o/Iiqarp+Wb10nx5ZRDigJF2Qhc="
     },
     "js-tokens": {
       "version": "4.0.0",
@@ -3684,6 +3747,11 @@
       "resolved": "https://registry.npmjs.org/qs/-/qs-6.7.0.tgz",
       "integrity": "sha512-VCdBRNFTX1fyE7Nb6FYoURo/SPe62QCaAyzJvUjwRaIsc+NePBEniHlvxFmmX56+HZphIGtV0XeCirBtpDrTyQ=="
     },
+    "querystring": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz",
+      "integrity": "sha1-sgmEkgO7Jd+CDadW50cAWHhSFiA="
+    },
     "ramda": {
       "version": "0.27.1",
       "resolved": "https://registry.npmjs.org/ramda/-/ramda-0.27.1.tgz",
@@ -4477,6 +4545,22 @@
         "punycode": "^2.1.0"
       }
     },
+    "url": {
+      "version": "0.10.3",
+      "resolved": "https://registry.npmjs.org/url/-/url-0.10.3.tgz",
+      "integrity": "sha1-Ah5NnHcF8hu/N9A861h2dAJ3TGQ=",
+      "requires": {
+        "punycode": "1.3.2",
+        "querystring": "0.2.0"
+      },
+      "dependencies": {
+        "punycode": {
+          "version": "1.3.2",
+          "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz",
+          "integrity": "sha1-llOgNvt8HuQjQvIyXM7v6jkmxI0="
+        }
+      }
+    },
     "util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
@@ -4629,6 +4713,20 @@
       "version": "7.4.2",
       "resolved": "https://registry.npmjs.org/ws/-/ws-7.4.2.tgz",
       "integrity": "sha512-T4tewALS3+qsrpGI/8dqNMLIVdq/g/85U98HPMa6F0m6xTbvhXU6RCQLqPH3+SlomNV/LdY6RXEbBpMH6EOJnA=="
+    },
+    "xml2js": {
+      "version": "0.4.19",
+      "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.19.tgz",
+      "integrity": "sha512-esZnJZJOiJR9wWKMyuvSE1y6Dq5LCuJanqhxslH2bxM6duahNZ+HMpCLhBQGZkbX6xRf8x1Y2eJlgt2q3qo49Q==",
+      "requires": {
+        "sax": ">=0.6.0",
+        "xmlbuilder": "~9.0.1"
+      }
+    },
+    "xmlbuilder": {
+      "version": "9.0.7",
+      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-9.0.7.tgz",
+      "integrity": "sha1-Ey7mPS7FVlxVfiD0wi35rKaGsQ0="
     },
     "xregexp": {
       "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "@cardano-ogmios/client": "^4.0.0",
     "@cardano-ogmios/schema": "^4.0.0",
     "@emurgo/cardano-serialization-lib-nodejs": "^4.2.0",
+    "aws-sdk": "^2.1036.0",
     "axios": "^0.21.1",
     "bech32": "^1.1.4",
     "cardano-wallet": "^1.2.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "yoroi-cardano-backend",
-  "version": "2.3.6",
+  "version": "2.3.8",
   "description": "Wrapped for cardano-db-sync and cardano-graphql with endpoints useful for light wallets",
   "main": "src/index.ts",
   "scripts": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -408,7 +408,7 @@ const routes: Route[] = [
   },
   {
     path: "/multiAsset/validateNFT/:fingerprint",
-    method: "get",
+    method: "post",
     handler: handleValidateNft(pool)
   },
   {

--- a/src/index.ts
+++ b/src/index.ts
@@ -29,6 +29,7 @@ import { handleGetMultiAssetSupply } from "./services/multiAssetSupply";
 import { handleGetMultiAssetTxMintMetadata } from "./services/multiAssetTxMint";
 import { handleTxStatus } from "./services/txStatus";
 import { handleTipStatusGet, handleTipStatusPost } from "./services/tipStatus";
+import { handleValidateNft } from "./services/validateNft";
 
 import { HealthChecker } from "./HealthChecker";
 
@@ -349,6 +350,11 @@ const routes : Route[] = [
     path: "/multiAsset/metadata",
     method: "post",
     handler: handleGetMultiAssetTxMintMetadata(pool)
+  },
+  {
+    path: "/multiAsset/validateNFT/:fingerprint",
+    method: "get",
+    handler: handleValidateNft(pool)
   },
   {
     path: "/tx/status",

--- a/src/services/validateNft.ts
+++ b/src/services/validateNft.ts
@@ -1,0 +1,150 @@
+import config from "config";
+import { Pool } from "pg";
+import { Request, Response } from "express";
+
+import AWS from "aws-sdk";
+
+const query = `SELECT encode(asset.policy, 'hex') as "policy",
+  encode(asset.name, 'escape') as "name",
+  meta.key as "meta_label",
+  meta.json as "metadata"
+FROM multi_asset asset
+  INNER JOIN ma_tx_mint mint on asset.id = mint.ident
+  INNER JOIN tx on mint.tx_id = tx.id
+  INNER JOIN tx_metadata meta on tx.id = meta.tx_id
+WHERE asset.fingerprint = $1::text`;
+
+const getLambda = (): AWS.Lambda => {
+  const lambdaEndpoint = config.get("aws.lambdaEndpoint") as string;
+  if (lambdaEndpoint) {
+    return new AWS.Lambda({
+      endpoint: lambdaEndpoint,
+      region: config.get("aws.region"),
+      credentials: {
+        accessKeyId: config.get("aws.accessKeyId"),
+        secretAccessKey: config.get("aws.secretAccessKey"),
+      }
+    });
+  } else {
+    return new AWS.Lambda({
+      region: config.get("aws.region"),
+      credentials: {
+        accessKeyId: config.get("aws.accessKeyId"),
+        secretAccessKey: config.get("aws.secretAccessKey"),
+      }
+    });
+  }
+};
+
+type NftValidationData = {
+  smallVariantFile?: string
+  largeVariantFile?: string
+  contentsOnImage?: string[]
+  category?: string
+  validated: boolean
+}
+
+const getNftValidationData = async (lambda: AWS.Lambda, fingerprint: string): Promise<NftValidationData> => {
+  const lambdaResponse = await lambda.invoke({
+    FunctionName: "YoroiContentValidator",
+    InvocationType: "RequestResponse",
+    Payload: JSON.stringify({
+      action: "Verify",
+      fingerprint: fingerprint
+    })
+  }).promise();
+
+  if (lambdaResponse.StatusCode === 200) {
+    const lambdaResponseObj: NftValidationData = JSON.parse(lambdaResponse.Payload?.toString("utf-8") ?? "{}");
+    return lambdaResponseObj; 
+  }
+
+  throw new Error("unexpected error");
+};
+
+const sendNftForValidation = (
+  lambda: AWS.Lambda,
+  fingerprint: string,
+  metadatImage: string
+): void => {
+  lambda.invoke({
+    FunctionName: "YoroiContentValidator",
+    InvocationType: "Event",
+    Payload: JSON.stringify({
+      action: "Validate",
+      nfts: [
+        {
+          assetFingerprint: fingerprint,
+          metadata: {
+            image: metadatImage
+          }
+        }
+      ]
+    })
+  }, (err, data) => {
+    if (err) {
+      console.error(err);
+    } else {
+      console.info(data);
+    }
+  });
+};
+
+export const handleValidateNft = (pool: Pool) => async (req: Request, res: Response) => {
+  const fingerprint: string = req.params.fingerprint;
+  if (!fingerprint) {
+    return res.status(400).send({
+      error: "missing fingerprint"
+    });
+  }
+
+  const lambda = getLambda();
+  const nftValidationData = await getNftValidationData(lambda, fingerprint);
+  if (nftValidationData.validated) {
+    return res.status(200)
+      .send(nftValidationData);
+  }
+
+  const result = await pool.query(query, [fingerprint]);
+  if (result.rowCount === 0) {
+    return res.status(404).send({
+      error: "Not found"
+    });
+  }
+
+  const item = result.rows[0];
+  if (item.meta_label !== "721") {
+    return res.status(409)
+      .send({
+        error: `the asset was found, but it has an incorrect metadata label. Expected '721, but it is ${item.meta_label}`
+      });
+  }
+
+  if (!item.metadata[item.policy]) {
+    return res.status(409)
+      .send({
+        metadata: item.metadata,
+        error: `missing policy ('${item.policy}') field on metadata`
+      });
+  }
+
+  if (!item.metadata[item.policy][item.name]) {
+    return res.status(409).send({
+      metadata: item.metadata,
+      error: `missing name ('${item.name}') field on metadata`
+    });
+  }
+
+  const metadata = item.metadata[item.policy][item.name];
+  if (!metadata.image) {
+    return res.status(409).send({
+      metadata: item.metadata,
+      error: "missing image field on metadata"
+    });
+  }
+
+  sendNftForValidation(lambda, fingerprint, metadata.image);
+
+  return res.status(204)
+    .send();
+};

--- a/src/services/validateNft.ts
+++ b/src/services/validateNft.ts
@@ -143,8 +143,13 @@ export const handleValidateNft = (pool: Pool) => async (req: Request, res: Respo
     });
   }
 
+  if (req.query.skipValidation) {
+    return res.status(204)
+      .send();  
+  }
+
   sendNftForValidation(lambda, fingerprint, metadata.image);
 
-  return res.status(204)
+  return res.status(202)
     .send();
 };

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -36,7 +36,7 @@ type Handler = (
   req: Request,
   res: Response,
   next: NextFunction
-) => Promise<void> | void;
+) => Promise<void> | void | Promise<Response>;
 
 export interface Route {
   path: string;

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -41,7 +41,7 @@ type Handler = (
 export interface Route {
   path: string;
   method: string;
-  handler: Handler | Handler[];
+  handler: Handler | Handler[] | Response;
 }
 
 export const applyRoutes = (routes: Route[], router: Router) => {


### PR DESCRIPTION
Adds an endpoint for triggering [`Yoroi Content Validator`](https://github.com/Emurgo/yoroi-content-validator) for a given NFT fingerprint, or return the current validation results in case the validation was already performed

### NOTICE
for testing purposes this branch was rebased to [fix/change-endpoints-to-use-multi-asset-table](https://github.com/Emurgo/yoroi-graphql-migration-backend/tree/fix/change-endpoints-to-use-multi-asset-table) #284 