### PR TITLE
add asset mint txs endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -946,3 +946,23 @@ We recommend querying using payment key hashes (`addr_vkh`) when possible (other
   }
   ```
 </details>
+<details>
+  <summary>/asset/:fingerprint/mintTxs</summary>
+  Retrieves all minting transactions for the given asset fingerprint together with its metadata, if any.
+
+  Output
+
+  ```js
+  {
+    policy: string, // hex-encoded policy
+    name: string, // hex-encoded asset name
+    txs: Array<{
+      hash: string,
+      metadata?: {
+        key: number,
+        json: any
+      }
+    }>
+  }
+  ```
+</details>

--- a/src/index.ts
+++ b/src/index.ts
@@ -38,6 +38,7 @@ import { handleGetRegHistory } from "./services/regHistory";
 import { handleGetRewardHistory } from "./services/rewardHistory";
 import { handleGetMultiAssetSupply } from "./services/multiAssetSupply";
 import { handleGetMultiAssetTxMintMetadata } from "./services/multiAssetTxMint";
+import { handleGetAssetMintTxs } from "./services/assetMintTxs";
 import { handleTxStatus } from "./services/txStatus";
 import { handleUtxoDiffSincePoint } from "./services/utxoDiffSincePoint";
 import { handleGetTxIO, handleGetTxOutput } from "./services/txIO";
@@ -425,6 +426,11 @@ const routes: Route[] = [
     path: "/multiAsset/metadata",
     method: "post",
     handler: handleGetMultiAssetTxMintMetadata(pool),
+  },
+  {
+    path: "/asset/:fingerprint/mintTxs",
+    method: "get",
+    handler: handleGetAssetMintTxs(pool),
   },
   {
     path: "/tx/status",

--- a/src/services/assetMintTxs.ts
+++ b/src/services/assetMintTxs.ts
@@ -1,0 +1,38 @@
+import { Pool } from "pg";
+import { Request, Response } from "express";
+
+const getAssetMintMetadata = async (pool: Pool, fingerprint: string) => {
+  const query = `
+  select encode(ma.policy, 'hex') as policy,
+    encode(ma.name, 'hex') as asset,
+    ma.fingerprint,
+    json_agg(
+        cast ('{"hash": "' || encode(tx.hash, 'hex') || '"}' as jsonb)
+        || jsonb_build_object('metadata', cast ('{"key": ' || meta.key || '}' as jsonb)
+            || jsonb_build_object('json', meta.json))
+    ) as txs
+from ma_tx_mint mint
+    join multi_asset ma on mint.ident = ma.id
+    join tx on mint.tx_id = tx.id
+    left join tx_metadata meta on tx.id = meta.tx_id
+where ma.fingerprint = $1
+group by ma.policy,
+    ma.name,
+    ma.fingerprint;`;
+
+  const results = await pool.query(query, [fingerprint]);
+  return results.rows.map(x => ({
+    policy: x.policy,
+    name: x.asset,
+    txs: x.txs
+  }));
+};
+
+export const handleGetAssetMintTxs =
+  (pool: Pool) =>
+  async (req: Request, res: Response): Promise<void> => {
+    if (!req.params.fingerprint) throw new Error("missing fingerprint in request params");
+
+    const metadata = await getAssetMintMetadata(pool, req.params.fingerprint);
+    res.send(metadata);
+  };

--- a/src/services/assetMintTxs.ts
+++ b/src/services/assetMintTxs.ts
@@ -21,11 +21,15 @@ group by ma.policy,
     ma.fingerprint;`;
 
   const results = await pool.query(query, [fingerprint]);
-  return results.rows.map((x) => ({
-    policy: x.policy,
-    name: x.asset,
-    txs: x.txs,
-  }));
+
+  if (results.rows.length === 0) return null;
+  const row = results.rows[0];
+
+  return {
+    policy: row.policy,
+    name: row.asset,
+    txs: row.txs,
+  };
 };
 
 export const handleGetAssetMintTxs =

--- a/src/services/assetMintTxs.ts
+++ b/src/services/assetMintTxs.ts
@@ -21,17 +21,18 @@ group by ma.policy,
     ma.fingerprint;`;
 
   const results = await pool.query(query, [fingerprint]);
-  return results.rows.map(x => ({
+  return results.rows.map((x) => ({
     policy: x.policy,
     name: x.asset,
-    txs: x.txs
+    txs: x.txs,
   }));
 };
 
 export const handleGetAssetMintTxs =
   (pool: Pool) =>
   async (req: Request, res: Response): Promise<void> => {
-    if (!req.params.fingerprint) throw new Error("missing fingerprint in request params");
+    if (!req.params.fingerprint)
+      throw new Error("missing fingerprint in request params");
 
     const metadata = await getAssetMintMetadata(pool, req.params.fingerprint);
     res.send(metadata);


### PR DESCRIPTION
This PR adds an endpoint for retrieving all mint transactions for a given asset fingerprint together with their respective metadata if it has any.