### PR TITLE
Fix `dataHash` format error

### DIFF
--- a/src/Transactions/userDefinedFunctions.ts
+++ b/src/Transactions/userDefinedFunctions.ts
@@ -97,7 +97,7 @@ BEGIN
         SELECT json_agg(
             ("address"
             , "value"
-            , "txDataHash"
+            , encode("txDataHash", 'hex')
             , (
                 SELECT json_agg(ROW(encode("policy", 'hex'), encode("name", 'hex'), "quantity"))
                 FROM ma_tx_out


### PR DESCRIPTION
The bug:
```
$ curl https://iohk-mainnet.yoroiwallet.com/api/txs/io/8dd71b5a737b076fda5432b2954cdbf164a26ed892768504986d8742b7bae87d/o/0 | jq .

{
  "output": {
      ...
    "dataHash": "\\xcd7250596c2b8e7ccff79c44939195561b1f2dd6abc310345d52b43f67a21e40",
...
```
The `\\x` prefix should not be there.