### PR TITLE
Validate nft by env

### DIFF
--- a/config/default.ts
+++ b/config/default.ts
@@ -19,7 +19,7 @@ export default {
   usingQueueEndpoint: process.env.USE_SIGNED_TX_QUEUE || "false",
   aws: {
     lambda: {
-      nftValidator: process.env.NFT_VALIDATOR_LAMBDA || "devNftValidatorLambda"
+      nftValidator: process.env.NFT_VALIDATOR_LAMBDA || "{envName}NftValidatorLambda"
     },
     accessKeyId: process.env.AWS_ACCESS_KEY_ID || "",
     secretAccessKey: process.env.AWS_SECRET_ACCESS_KEY || "",

--- a/config/default.ts
+++ b/config/default.ts
@@ -19,7 +19,7 @@ export default {
   usingQueueEndpoint: process.env.USE_SIGNED_TX_QUEUE || "false",
   aws: {
     lambda: {
-      nftValidator: process.env.NFT_VALIDATOR_LAMBDA || "{envName}NftValidatorLambda"
+      nftValidator: "{envName}NftValidatorLambda"
     },
     accessKeyId: process.env.AWS_ACCESS_KEY_ID || "",
     secretAccessKey: process.env.AWS_SECRET_ACCESS_KEY || "",

--- a/src/services/validateNft.ts
+++ b/src/services/validateNft.ts
@@ -29,8 +29,13 @@ const verifyExistingAnalysis = async (
   fingerprint: string,
   envName: string
 ) => {
-  const nftValidatorLambdaNameTemplate: string = config.get("aws.lambda.nftValidator");
-  const functionName = nftValidatorLambdaNameTemplate.replace("{envName}", envName);
+  const nftValidatorLambdaNameTemplate: string = config.get(
+    "aws.lambda.nftValidator"
+  );
+  const functionName = nftValidatorLambdaNameTemplate.replace(
+    "{envName}",
+    envName
+  );
 
   const response = await lambda
     .invoke({
@@ -55,8 +60,13 @@ const sendNftForAnalysis = async (
   metadatImage: string,
   envName: string
 ): Promise<void> => {
-  const nftValidatorLambdaNameTemplate: string = config.get("aws.lambda.nftValidator");
-  const functionName = nftValidatorLambdaNameTemplate.replace("{envName}", envName);
+  const nftValidatorLambdaNameTemplate: string = config.get(
+    "aws.lambda.nftValidator"
+  );
+  const functionName = nftValidatorLambdaNameTemplate.replace(
+    "{envName}",
+    envName
+  );
 
   const response = await lambda
     .invoke({
@@ -87,7 +97,11 @@ export const handleValidateNft =
     const envName = req.body.envName ?? "dev";
 
     const lambda = getLambda();
-    const existingAnalysis = await verifyExistingAnalysis(lambda, fingerprint, envName);
+    const existingAnalysis = await verifyExistingAnalysis(
+      lambda,
+      fingerprint,
+      envName
+    );
     if (existingAnalysis !== "NOT_FOUND") {
       return res.status(200).send(existingAnalysis);
     }

--- a/src/services/validateNft.ts
+++ b/src/services/validateNft.ts
@@ -26,11 +26,15 @@ const getLambda = (): AWS.Lambda => {
 
 const verifyExistingAnalysis = async (
   lambda: AWS.Lambda,
-  fingerprint: string
+  fingerprint: string,
+  envName: string
 ) => {
+  const nftValidatorLambdaNameTemplate: string = config.get("aws.lambda.nftValidator");
+  const functionName = nftValidatorLambdaNameTemplate.replace("{envName}", envName);
+
   const response = await lambda
     .invoke({
-      FunctionName: config.get("aws.lambda.nftValidator"),
+      FunctionName: functionName,
       InvocationType: "RequestResponse",
       Payload: JSON.stringify({
         action: "Verify",
@@ -48,11 +52,15 @@ const verifyExistingAnalysis = async (
 const sendNftForAnalysis = async (
   lambda: AWS.Lambda,
   fingerprint: string,
-  metadatImage: string
+  metadatImage: string,
+  envName: string
 ): Promise<void> => {
+  const nftValidatorLambdaNameTemplate: string = config.get("aws.lambda.nftValidator");
+  const functionName = nftValidatorLambdaNameTemplate.replace("{envName}", envName);
+
   const response = await lambda
     .invoke({
-      FunctionName: config.get("aws.lambda.nftValidator"),
+      FunctionName: functionName,
       InvocationType: "Event",
       Payload: JSON.stringify({
         action: "Validate",
@@ -76,8 +84,10 @@ export const handleValidateNft =
       });
     }
 
+    const envName = req.body.envName ?? "dev";
+
     const lambda = getLambda();
-    const existingAnalysis = await verifyExistingAnalysis(lambda, fingerprint);
+    const existingAnalysis = await verifyExistingAnalysis(lambda, fingerprint, envName);
     if (existingAnalysis !== "NOT_FOUND") {
       return res.status(200).send(existingAnalysis);
     }
@@ -122,7 +132,7 @@ export const handleValidateNft =
       return res.status(204).send();
     }
 
-    await sendNftForAnalysis(lambda, fingerprint, metadata.image);
+    await sendNftForAnalysis(lambda, fingerprint, metadata.image, envName);
 
     return res.status(202).send();
   };


### PR DESCRIPTION
On Fibo we have more distinct environments than Yoroi, therefore we cannot rely on the env var to define which version of the Lambda should be used. The dev, QA and staging environments on Fibo interact with the testnet environment of Yoroi backend, therefore, we need this extra field in the payload to make the distinction of which Lambda to call.