### PR TITLE
fix broken postinstall for coin price data fetcher when building Docker image

### DIFF
--- a/script/coin-price-data-fetcher/.npmrc
+++ b/script/coin-price-data-fetcher/.npmrc
@@ -1,0 +1,1 @@
+unsafe-perm=true


### PR DESCRIPTION
When docker builds the images, it uses the `root` user to run the `npm install` command. But `npm` doesn't allow root user to run the postinstall script without `unsafe-perm=true`. This PR adds the option.