### PR TITLE
If price fetcher is not active, don't access the env vars

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "yoroi-cardano-backend",
-  "version": "2.5.9",
+  "version": "2.5.10",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "yoroi-cardano-backend",
-  "version": "2.5.9",
+  "version": "2.5.10",
   "description": "Wrapped for cardano-db-sync and cardano-graphql with endpoints useful for light wallets",
   "main": "src/index.ts",
   "scripts": {

--- a/script/coin-price-data-fetcher/src/uploader.js
+++ b/script/coin-price-data-fetcher/src/uploader.js
@@ -6,16 +6,27 @@ const logger = require('./logger');
 
 import type { Ticker } from './types';
 
-AWS.config.update({region: config.get("s3.region")});
+let _S3 = null;
 
-const S3 = new AWS.S3({
-  accessKeyId: config.get('s3.accessKeyId'),
-  secretAccessKey: config.get('s3.secretAccessKey'),
-});
+function getS3() {
+  if (_S3) {
+    return _S3;
+  }
+
+  AWS.config.update({region: config.get("s3.region")});
+
+  _S3 = new AWS.S3({
+    accessKeyId: config.get('s3.accessKeyId'),
+    secretAccessKey: config.get('s3.secretAccessKey'),
+  });
+
+  return _S3;
+}
 
 const RETRY_COUNT = 3;
 
 async function upload(ticker: Ticker): Promise<void> {
+  const S3 = getS3();
   const fileName = `prices-${ticker.from}-${ticker.timestamp}.json`;
   const uploadParams = {
     Body: JSON.stringify(ticker),


### PR DESCRIPTION
This is an improvement, no need for redeployment for this patch. We can merge into mater and wait for the next upgrade.