### PR TITLE
multiasset info query accepts asset name in hex

### DIFF
--- a/README.md
+++ b/README.md
@@ -937,6 +937,15 @@ We recommend querying using payment key hashes (`addr_vkh`) when possible (other
   Retrieves on-chain metadata for assets.
 
   Input
+  ```js
+  {
+    assets: Array<{
+      nameHex: string,
+      policy: string,
+    }>
+  }
+  ```
+  or
 
   ```js
   {
@@ -946,6 +955,9 @@ We recommend querying using payment key hashes (`addr_vkh`) when possible (other
     }>
   }
   ```
+
+  Prefer the first one, where the asset names are passes as hex strings via the `nameHex` field.
+
 
   Output
 


### PR DESCRIPTION
Originally the multi-asset metadata endpoint `multiAsset/metadata` takes parameters in this form:
```
{
  "assets":[
     {"name":"...", "policy": "..."},
     ...
  ]
}
```
And the "name" is the asset name in hex decoded as an ASCII string.
The problem is that the blockchain protocol does not mandate the name to an ASCII string, nor even an UTF8 string. For example:
https://testnet.cardanoscan.io/tokens?pageNo=12&policyId=b940743438a9217ea9d673362f708e5080dcd7b597988ae962782e10. So a query containing a token with name like `ab6854726b0139254b7e5c4831c87ac043a938fa3543b5eb0ce0906e122083e9` leads to the PSQL error "invalid input syntax for type bytea".

This PR accepts the asset name in a hex string as the `nameHex` field.
```
{
  "assets":[
     {"nameHex":"...", "policy": "..."},
     ...
  ]
}
```
For backward-compatibity, `name` is also accept and the semantics aren't changed.
