### PR TITLE
Fix the utxoDiffSincePoint endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,8 +130,10 @@ We recommend querying using payment key hashes (`addr_vkh`) when possible (other
 
 <details>
   <summary>v2/txs/utxoDiffSincePoint</summary>
+
   Returns a diff of inputs and outputs between two points. See the comments next to the request parameters for more information.
-  This endpoint is better used in combination with `v2/txs/utxoAtPoint`. After making a request to `v2/txs/utxoAtPoint`, the clients can keep their local copy of the UTxO state by calling `v2/txs/utxoDiffSincePoint` with `afterPoint` or `afterBestBlocks` being built using the block from the previous request as a reference point and making any changes established by the diff, so essentially discarding outputs which have been returned in the diff as inputs and including the new outputs returned by the diff.
+
+  This endpoint is better used in combination with `v2/txs/utxoAtPoint`. After making a request to `v2/txs/utxoAtPoint`, the clients can keep their local copy of the UTxO state by calling `v2/txs/utxoDiffSincePoint` with `afterBlockHash` being the block from the previous request as a reference point and making any changes established by the diff, so essentially discarding outputs which have been returned in the diff as inputs and including the new outputs returned by the diff.
 
 
   Input
@@ -141,11 +143,8 @@ We recommend querying using payment key hashes (`addr_vkh`) when possible (other
     // byron addresses, bech32 address, bech32 stake addresses or addr_vkh
     addresses: Array<string>,
     untilBlockHash: string, // only transactions up to this block (including it) will be considered for generating the diff
-    afterPoint?: {
-      blockHash: string, // only transactions AFTER this clock will be considered for generating the diff
-      itemIndex?: number // if `itemIndex` is supplied, we will also consider transactions from `blockHash`, but only the outputs which have a bigger index than `itemIndex`
-    },
-    afterBestBlocks?: Array<string> // only transactions after the latest block from this array will be included. The inclusion of `afterBestBlocks` in the request will also add 2 new fields to the response (see the response bellow for more details)
+    afterBlockHash: string, // only transactions AFTER this block will be considered for generating the diff
+    blockCount: number, // only this count of blocks will be considered. Note this means the last block considered may not reach `untilBlockHash` and repeated calls should be made, with `afterBlockHash` being the `lastBlockHash` of previous return value.
   }
   ```
 
@@ -160,8 +159,7 @@ We recommend querying using payment key hashes (`addr_vkh`) when possible (other
       assets?: Asset[], // only included for outputs
       block_num?: number // only included for outputs
     }>,
-    lastFoundBestBlock?: string, // only included if `afterBestBlocks` was supplied. This will be the latest found block from `afterBestBlocks`
-    lastFoundSafeBlock?: string // only included if `afterBestBlocks` was supplied. This will be the latest safe block from `afterBestBlocks`, safe block being the block with the highest depth up to a maximum, determined at runtime by configuration
+    lastBlockHash: string, // the last block considered. If it equals `untilBlockHash`, it means the number of blocks from `afterBlockHash` to `untilBlock` is less than or equal to `blockCount` and all these blocks are considerd when generating the diff.
   }
   ```
 </details>

--- a/src/services/utxoDiffSincePoint.ts
+++ b/src/services/utxoDiffSincePoint.ts
@@ -245,6 +245,7 @@ export const handleUtxoDiffSincePoint =
         if (result.rows.length === 0) {
           apiResponse.diffItems = [];
           res.send(apiResponse);
+          return;
         }
 
         const linearized = [];

--- a/src/utils/queries/block.ts
+++ b/src/utils/queries/block.ts
@@ -2,7 +2,7 @@ import { Pool } from "pg";
 
 import { BlockFrag } from "../../Transactions/types";
 
-const baseGetBlockQuery = `SELECT encode(hash, 'hex'),
+const baseGetBlockQuery = `SELECT encode(hash, 'hex') as hash,
   epoch_no,
   slot_no,
   block_no
@@ -43,6 +43,28 @@ export const getBlock =
 
     const row = result.rows[0];
 
+    return {
+      epochNo: row.epoch_no,
+      hash: row.hash,
+      slotNo: row.slot_no,
+      number: row.block_no,
+    };
+  };
+
+export const getBlockByNumber =
+  (pool: Pool) =>
+  async (blockNumber: number): Promise<BlockFrag | undefined> => {
+    const result = await pool.query(
+      `${baseGetBlockQuery}
+       WHERE block_no = $1`,
+      [blockNumber]
+    );
+
+    if (!result.rows || result.rows.length === 0) {
+      return undefined;
+    }
+
+    const row = result.rows[0];
     return {
       epochNo: row.epoch_no,
       hash: row.hash,


### PR DESCRIPTION
There are some issues with `utxoDiffSincePoint`'s handling of linearization (ref: https://emurgo.atlassian.net/wiki/spaces/CARDANO/pages/679706630/UTxO+API+Rework#Linearization) of diff items that may cause problems during paging of the results.

To paginate the results, the caller passes a `diffLimit` number for the number of results in one page and receives a `lastDiffPointSelected` return value, which is passed to `afterPoint` when making the next call (ref: https://github.com/Emurgo/yoroi-lib/blob/main/src/utxo/emurgo-api.ts#L299). The structure of `lastDiffPointSelected`/`afterPoint` is  `{blockHash, txHash, itemIndex}`, but this is insufficient to define a point in the linearization of diff items. The linearization is `[...txDiffInputs(tx), ...txDiffOutputs(tx)]`, but `itemIndex` is an index into `txDiffOutputs(tx)`, and there is no way to identify a point inside the `txDiffInputs(tx)` part. The problem is reflected in the query built by the handler:
```
     1	SELECT * FROM (
     2	    SELECT tx_out.address
     3	  , encode(block.hash, 'hex') as "blockHash"
     4	  , tx_out.address
     5	  , tx_out.payment_cred
     6	  , encode(tx.hash,'hex') as hash
     7	  , tx_out.index
     8	  , tx_out.value
     9	  , block.block_no as "blockNumber"
    10	  , (
    11	    select json_agg(ROW (encode(multi_asset."policy", 'hex'), encode(multi_asset."name", 'hex'), "quantity"))
    12	    from ma_tx_out
    13	      inner join multi_asset on ma_tx_out.ident = multi_asset.id
    14	    where ma_tx_out."tx_out_id" = tx_out.id
    15	  ) as assets
    16	  , 'I' as "type"
    17	  FROM tx
    18	  INNER JOIN block ON tx.block_id = block.id
    19	  INNER JOIN tx_in ON tx.id = tx_in.tx_in_id
    20	  INNER JOIN tx_out
    21	    ON tx_out.tx_id = tx_in.tx_out_id
    22	    AND tx_out.index::smallint = tx_in.tx_out_index::smallint
    23	  WHERE tx.valid_contract
    24	  AND block.block_no <= ($3)::word31type
    25	  AND (
    26	      block.block_no > ($4)::word31type
    27	      OR (
    28	        block.block_no >= ($4)::word31type
    29	        AND encode(tx.hash,'hex') = ($5)::varchar
    30	        AND tx_out.index > ($6)::txindex
    31	      )
    32	    )
    33	  AND (
    34	    tx_out.address = any(($1)::varchar array) 
    35	    OR tx_out.payment_cred = any(($2)::bytea array)
    36	  )
    37	    UNION ALL
    38	    SELECT tx_out.address
    39	  , encode(block.hash, 'hex') as "blockHash"
    40	  , tx_out.address
    41	  , tx_out.payment_cred
    42	  , encode(tx.hash,'hex') as hash
    43	  , tx_out.index
    44	  , tx_out.value
    45	  , block.block_no as "blockNumber"
    46	  , (
    47	    select json_agg(ROW (encode(multi_asset."policy", 'hex'), encode(multi_asset."name", 'hex'), "quantity"))
    48	    from ma_tx_out
    49	      inner join multi_asset on ma_tx_out.ident = multi_asset.id
    50	    where ma_tx_out."tx_out_id" = tx_out.id
    51	  ) as assets
    52	  , 'I' as "type"
    53	  FROM tx
    54	  INNER JOIN block ON tx.block_id = block.id
    55	  INNER JOIN collateral_tx_in ON tx.id = collateral_tx_in.tx_in_id
    56	  INNER JOIN tx_out
    57	    ON tx_out.tx_id = collateral_tx_in.tx_out_id
    58	    AND tx_out.index::smallint = collateral_tx_in.tx_out_index::smallint
    59	  WHERE NOT tx.valid_contract
    60	  AND block.block_no <= ($3)::word31type
    61	  AND (
    62	      block.block_no > ($4)::word31type
    63	      OR (
    64	        block.block_no >= ($4)::word31type
    65	        AND encode(tx.hash,'hex') = ($5)::varchar
    66	        AND tx_out.index > ($6)::txindex
    67	      )
    68	    )
    69	  AND (
    70	    tx_out.address = any(($1)::varchar array) 
    71	    OR tx_out.payment_cred = any(($2)::bytea array)
    72	  )
    73	    UNION ALL
    74	    SELECT tx_out.address
    75	  , encode(block.hash, 'hex') as "blockHash"
    76	  , tx_out.address
    77	  , tx_out.payment_cred
    78	  , encode(tx.hash,'hex') as hash
    79	  , tx_out.index
    80	  , tx_out.value
    81	  , block.block_no as "blockNumber"
    82	  , (
    83	    select json_agg(ROW (encode(multi_asset."policy", 'hex'), encode(multi_asset."name", 'hex'), "quantity"))
    84	    from ma_tx_out
    85	      inner join multi_asset on ma_tx_out.ident = multi_asset.id
    86	    where ma_tx_out."tx_out_id" = tx_out.id
    87	  ) as assets
    88	  , 'O' as "type"
    89	  FROM tx
    90	  INNER JOIN block ON tx.block_id = block.id
    91	  INNER JOIN tx_out ON tx.id = tx_out.tx_id
    92	  WHERE tx.valid_contract
    93	  AND block.block_no <= ($3)::word31type
    94	  AND (
    95	      block.block_no > ($4)::word31type
    96	      OR (
    97	        block.block_no >= ($4)::word31type
    98	        AND encode(tx.hash,'hex') = ($5)::varchar
    99	        AND tx_out.index > ($6)::txindex
   100	      )
   101	    )
   102	  AND (
   103	    tx_out.address = any(($1)::varchar array) 
   104	    OR tx_out.payment_cred = any(($2)::bytea array)
   105	  )
   106	  ) as q
   107	  ORDER BY q."blockNumber", CASE q.type WHEN 'I' THEN 1 ELSE 0 END
   108	  LIMIT $7::word31type;
```
Note that at line 30, what we intend to express is "the index of the input in the tx that contains the input > some value" but what the query actually expresses is "the index of the output used by the input in the tx that contains the output > some value".

Another problem with the filter between lines 25 and32 is that transactions after the specified one in the same block are ignored.

The first problem is difficult to fix under the current scheme because the tx inputs are not considered ordered by db-sync and unlike the `tx_out` table, the `tx_in` table doesn't have a `index` field. My proposal in this PR is to circumvent the problem by paginating by the number of blocks instead of by the number of diff items. So instead of the `diffLimit` parameter, the query takes a `blockCount`  parameter and only the specified number of blocks will be considered. Note this does mean that the number of returned diff items will vary, but since the number of transactions in a block and the number of inputs and outputs in a transaction are bound, the maximum number of returned diff items has an upper bound and the purpose of the pagination is also achieved.

