### PR TITLE
chore: rem addrs limit + cleanup

### DIFF
--- a/src/Transactions/types.ts
+++ b/src/Transactions/types.ts
@@ -206,8 +206,8 @@ export const rowToCertificate = (row: any): Certificate | null => {
         rewards: row.rewards === null ? {} : rewards,
       };
     }
-    default:
-      console.log(`Certificate from DB doesn't match any known type: ${row}`); // the app only logs errors.
+    default: // the app only logs errors.
+      console.log(`Certificate from DB doesn't match any known type: ${row}`);
       return null;
   }
 };

--- a/src/services/utxoAtPoint.ts
+++ b/src/services/utxoAtPoint.ts
@@ -1,10 +1,7 @@
 import { Pool } from "pg";
 import { Request, Response } from "express";
 
-import {
-  getAddressesByType,
-  extractAssets,
-} from "../utils";
+import { getAddressesByType, extractAssets } from "../utils";
 
 import { getBlock } from "../utils/queries/block";
 
@@ -69,9 +66,7 @@ export const utxoAtPoint =
     const offset = (page - 1) * pageSize;
     const addressTypes = getAddressesByType(addresses);
 
-    const referenceBlock = await getBlock(pool)(
-      req.body.referenceBlockHash
-    );
+    const referenceBlock = await getBlock(pool)(req.body.referenceBlockHash);
     if (!referenceBlock) {
       throw new Error("REFERENCE_POINT_BLOCK_NOT_FOUND");
     }

--- a/src/services/utxoDiffSincePoint.ts
+++ b/src/services/utxoDiffSincePoint.ts
@@ -7,10 +7,7 @@ import {
   getLatestSafeBlockFromHashes,
 } from "../utils/queries/block";
 import { getTransactionRowByHash } from "../utils/queries/transaction";
-import {
-  getAddressesByType,
-  extractAssets,
-} from "../utils";
+import { getAddressesByType, extractAssets } from "../utils";
 
 enum DiffItemType {
   INPUT = "input",
@@ -444,9 +441,7 @@ export const handleUtxoDiffSincePoint =
     const linearized = [];
     for (const row of result.rows) {
       if (
-        [DiffItemType.INPUT, DiffItemType.COLLATERAL].includes(
-          row.diffItemType
-        )
+        [DiffItemType.INPUT, DiffItemType.COLLATERAL].includes(row.diffItemType)
       ) {
         linearized.push({
           type: DiffItemType.INPUT,


### PR DESCRIPTION
### Abstract
---
The number of addresses limitation for the `utxosAtPoint` and `utxosDiffSincePoint` were capping the ability to tune it on the client side.

- It removes the number of addresses limitation for `utxosAtPoint` and `utxosDiffSincePoint` endpoints.

**This PR needs to be released before flipping mobile nightlies to production**